### PR TITLE
Added simple linear versioning of SchemaOperations.

### DIFF
--- a/src/main/java/io/quantumdb/core/utils/RandomHasher.java
+++ b/src/main/java/io/quantumdb/core/utils/RandomHasher.java
@@ -1,0 +1,23 @@
+package io.quantumdb.core.utils;
+
+import java.util.Random;
+
+public class RandomHasher {
+
+	private static final String CONTENTS = "abcdefgh0123456789";
+
+	private final Random random = new Random();
+
+	public String generate() {
+		StringBuilder builder = new StringBuilder();
+		int position = 0;
+
+		while (builder.length() < 7) {
+			position += random.nextInt(CONTENTS.length() * 4) % CONTENTS.length();
+			builder.append(CONTENTS.charAt(position % CONTENTS.length()));
+		}
+
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/io/quantumdb/core/versioning/ChangeSet.java
+++ b/src/main/java/io/quantumdb/core/versioning/ChangeSet.java
@@ -1,0 +1,55 @@
+package io.quantumdb.core.versioning;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import io.quantumdb.core.schema.operations.SchemaOperation;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+
+
+/**
+ * This class describes a list of SchemaOperations which batched together form a logical set of changes to the database
+ * schema. This batch can optionally be given a description, much like a commit message in version control systems.
+ */
+@Data
+public class ChangeSet {
+
+	private final String description;
+
+	@Getter(AccessLevel.NONE)
+	private final List<SchemaOperation> schemaOperations;
+
+	/**
+	 * Creates a new ChangeSet object based on the specified array of SchemaOperations. This ChangeSet will have no
+	 * description associated with it.
+	 *
+	 * @param operations A non-empty array of SchemaOperations that perform a logical set of operations.
+	 */
+	ChangeSet(SchemaOperation... operations) {
+		this(null, operations);
+	}
+
+	/**
+	 * Creates a new ChangeSet object based on the specified description and array of SchemaOperations.
+	 *
+	 * @param description The description of the ChangeSet (may be NULL).
+	 * @param operations  A non-empty array of SchemaOperations that perform a logical set of operations.
+	 */
+	ChangeSet(String description, SchemaOperation... operations) {
+		checkArgument(operations != null && operations.length > 0, "You must specify at least one schema operation.");
+
+		this.description = Strings.emptyToNull(description);
+		this.schemaOperations = Arrays.asList(operations);
+	}
+
+	public ImmutableList<SchemaOperation> getSchemaOperations() {
+		return ImmutableList.copyOf(schemaOperations);
+	}
+
+}

--- a/src/main/java/io/quantumdb/core/versioning/Changelog.java
+++ b/src/main/java/io/quantumdb/core/versioning/Changelog.java
@@ -1,0 +1,64 @@
+package io.quantumdb.core.versioning;
+
+import io.quantumdb.core.schema.operations.SchemaOperation;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+
+/**
+ * This class allows you to define a series of successive ChangeSets, building up a changelog in the process.
+ */
+@Data
+public class Changelog {
+
+	private final Version root;
+
+	@Setter(AccessLevel.NONE)
+	@Getter(AccessLevel.NONE)
+	private Version pointer;
+
+	/**
+	 * Creates a new Changelog object.
+	 */
+	public Changelog() {
+		this.root = Version.rootVersion();
+		this.pointer = this.root;
+	}
+
+	/**
+	 * @return The Version object last appended to this Changelog object.
+	 */
+	public Version getCurrent() {
+		return pointer;
+	}
+
+	/**
+	 * Adds a new ChangeSet to the Changelog object, based on the specified parameters.
+	 *
+	 * @param operations A non-empty array of SchemaOperations that perform a logical set of operations.
+	 *
+	 * @return The constructed ChangeSet object.
+	 */
+	public ChangeSet addChangeSet(SchemaOperation... operations) {
+		return addChangeSet(null, operations);
+	}
+
+	/**
+	 * Adds a new ChangeSet to the Changelog object, based on the specified parameters.
+	 *
+	 * @param description The description of the ChangeSet (may be NULL).
+	 * @param operations  A non-empty array of SchemaOperations that perform a logical set of operations.
+	 *
+	 * @return The constructed ChangeSet object.
+	 */
+	public ChangeSet addChangeSet(String description, SchemaOperation... operations) {
+		ChangeSet changeSet = new ChangeSet(description, operations);
+		for (SchemaOperation operation : operations) {
+			this.pointer = pointer.apply(operation, changeSet);
+		}
+		return changeSet;
+	}
+
+}

--- a/src/main/java/io/quantumdb/core/versioning/Version.java
+++ b/src/main/java/io/quantumdb/core/versioning/Version.java
@@ -1,0 +1,98 @@
+package io.quantumdb.core.versioning;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import io.quantumdb.core.schema.operations.SchemaOperation;
+import io.quantumdb.core.utils.RandomHasher;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
+import lombok.ToString;
+
+
+/**
+ * This class can be used to describe the evolution of the database at a given point in time. It resembles much of the
+ * idea of a commit in the distributed version control system Git, in such that it has a parent and that it holds
+ * information on the difference between the parent Version and this Version.
+ */
+@Data
+@ToString(of = { "id" })
+public class Version {
+
+	static Version rootVersion() {
+		RandomHasher hasher = new RandomHasher();
+		return new Version(hasher.generate(), null);
+	}
+
+	private final String id;
+
+	@Setter(AccessLevel.PRIVATE)
+	private Version parent;
+
+	@Setter(AccessLevel.PRIVATE)
+	private Version child;
+
+	@Setter(AccessLevel.PRIVATE)
+	private ChangeSet changeSet;
+
+	@Setter(AccessLevel.PRIVATE)
+	private SchemaOperation schemaOperation;
+
+	/**
+	 * Creates a new Version object based on the specified parameters.
+	 *
+	 * @param id     The unique identifier of this Version object.
+	 * @param parent The parent of this Version object (may be NULL in case of a root Version).
+	 */
+	Version(String id, Version parent) {
+		checkArgument(id != null, "You must specify a 'id'.");
+
+		this.id = id;
+		if (parent != null) {
+			linkToParent(parent);
+		}
+	}
+
+	/**
+	 * Sets the parent of this Version object. Note that you may only set the parent once.
+	 *
+	 * @param parent The parent Version of this Version.
+	 */
+	void linkToParent(Version parent) {
+		checkArgument(parent != null, "You must specify a 'parent'.");
+		checkState(this.parent == null, "You have already specified a 'parent' previously.");
+
+		this.parent = parent;
+		parent.addChild(this);
+	}
+
+	private void addChild(Version child) {
+		checkArgument(child != null, "You must specify a 'child'.");
+
+		this.child = child;
+	}
+
+	/**
+	 * Applies a SchemaOperation belonging to a specified ChangeSet to this Version object. The result is a new Version
+	 * object which has this object as a parent Version. It also keeps a reference to the ChangeSet to which it belongs
+	 * and stores a reference to the specified SchemaOperation.
+	 *
+	 * @param operation The SchemaOperation to apply to this Version.
+	 * @param changeSet The ChangeSet to which this SchemaOperation belongs.
+	 *
+	 * @return The next Version which describes this change based on this Version.
+	 */
+	public Version apply(SchemaOperation operation, ChangeSet changeSet) {
+		checkArgument(operation != null, "You must specify a 'operation'.");
+		checkArgument(changeSet != null, "You must specify a 'changeSet'.");
+
+		RandomHasher hasher = new RandomHasher();
+		Version version = new Version(hasher.generate(), this);
+		version.setSchemaOperation(operation);
+		version.setChangeSet(changeSet);
+		return version;
+	}
+
+
+}

--- a/src/test/java/io/quantumdb/core/versioning/ChangeSetTest.java
+++ b/src/test/java/io/quantumdb/core/versioning/ChangeSetTest.java
@@ -1,0 +1,64 @@
+package io.quantumdb.core.versioning;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.common.collect.ImmutableList;
+import io.quantumdb.core.schema.operations.SchemaOperation;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import org.junit.Test;
+
+public class ChangeSetTest {
+
+	@Test
+	public void testSimpleConstructor() {
+		SchemaOperation operation1 = SchemaOperations.dropTable("users");
+		SchemaOperation operation2 = SchemaOperations.dropTable("addresses");
+		ChangeSet changeSet = new ChangeSet(operation1, operation2);
+
+		assertNull(changeSet.getDescription());
+		assertEquals(ImmutableList.of(operation1, operation2), changeSet.getSchemaOperations());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSimpleConstructorWithNoArgumentsThrowsException() {
+		new ChangeSet();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSimpleConstructorWithNullAsArgumentThrowsException() {
+		new ChangeSet(null);
+	}
+
+	@Test
+	public void testConstructorWithEmptyStringNormalizesItToNull() {
+		ChangeSet changeSet = new ChangeSet("", SchemaOperations.dropTable("users"));
+
+		assertNull(changeSet.getDescription());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorWithNoSchemaOperationsThrowsException() {
+		new ChangeSet("");
+	}
+
+	@Test
+	public void testConstructor() {
+		SchemaOperation operation1 = SchemaOperations.dropTable("users");
+		SchemaOperation operation2 = SchemaOperations.dropTable("addresses");
+		ChangeSet changeSet = new ChangeSet("This is a simple change", operation1, operation2);
+
+		assertEquals("This is a simple change", changeSet.getDescription());
+		assertEquals(ImmutableList.of(operation1, operation2), changeSet.getSchemaOperations());
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testThatSchemaOperationsGetterReturnsAnImmutableList() {
+		SchemaOperation operation1 = SchemaOperations.dropTable("users");
+		ChangeSet changeSet = new ChangeSet("This is a simple change", operation1);
+
+		SchemaOperation operation2 = SchemaOperations.dropTable("addresses");
+		changeSet.getSchemaOperations().add(operation2);
+	}
+
+}

--- a/src/test/java/io/quantumdb/core/versioning/ChangelogTest.java
+++ b/src/test/java/io/quantumdb/core/versioning/ChangelogTest.java
@@ -1,0 +1,59 @@
+package io.quantumdb.core.versioning;
+
+import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
+import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
+import static io.quantumdb.core.schema.definitions.GenericColumnTypes.int8;
+import static io.quantumdb.core.schema.definitions.GenericColumnTypes.varchar;
+import static org.junit.Assert.assertEquals;
+
+import io.quantumdb.core.schema.operations.CreateTable;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import org.junit.Test;
+
+public class ChangelogTest {
+
+	@Test
+	public void testDefiningChangeSet() {
+		Changelog changelog = new Changelog();
+		Version parent = changelog.getCurrent();
+
+		CreateTable operation = SchemaOperations.createTable("users")
+				.with("id", int8(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
+				.with("name", varchar(255), NOT_NULL);
+
+		ChangeSet changeSet = changelog.addChangeSet("ChangeSet with a description", operation);
+
+		Version version = changelog.getCurrent();
+
+		assertEquals(changeSet, version.getChangeSet());
+		assertEquals(parent, version.getParent());
+		assertEquals(operation, version.getSchemaOperation());
+	}
+
+	@Test
+	public void testDefiningChangeSetWithMultipleOperations() {
+		Changelog changelog = new Changelog();
+		Version parent = changelog.getCurrent();
+
+		CreateTable operation1 = SchemaOperations.createTable("users")
+				.with("id", int8(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
+				.with("name", varchar(255), NOT_NULL);
+
+		CreateTable operation2 = SchemaOperations.createTable("addresses")
+				.with("id", int8(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
+				.with("address", varchar(255), NOT_NULL);
+
+		ChangeSet changeSet = changelog.addChangeSet(operation1, operation2);
+
+		Version version = changelog.getCurrent();
+		assertEquals(changeSet, version.getChangeSet());
+		assertEquals(operation2, version.getSchemaOperation());
+
+		Version previous = version.getParent();
+		assertEquals(changeSet, previous.getChangeSet());
+		assertEquals(operation1, previous.getSchemaOperation());
+		assertEquals(parent, previous.getParent());
+	}
+
+}

--- a/src/test/java/io/quantumdb/core/versioning/VersionTest.java
+++ b/src/test/java/io/quantumdb/core/versioning/VersionTest.java
@@ -1,0 +1,91 @@
+package io.quantumdb.core.versioning;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import io.quantumdb.core.schema.operations.SchemaOperation;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import org.junit.Test;
+
+public class VersionTest {
+
+	@Test
+	public void testStaticRootConstructor() {
+		Version version = Version.rootVersion();
+
+		assertNotNull(version.getId());
+		assertNull(version.getParent());
+		assertNull(version.getChild());
+		assertNull(version.getChangeSet());
+		assertNull(version.getSchemaOperation());
+	}
+
+	@Test
+	public void testConstructor() {
+		Version parent = Version.rootVersion();
+		Version version = new Version("some-id", parent);
+
+		assertEquals("some-id", version.getId());
+		assertEquals(parent, version.getParent());
+
+		assertNull(version.getChild());
+		assertNull(version.getChangeSet());
+		assertNull(version.getSchemaOperation());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorWithNullAsVersionIdWillThrowException() {
+		Version parent = Version.rootVersion();
+		new Version(null, parent);
+	}
+
+	@Test
+	public void testConstructorWithNullAsParentIsAllowed() {
+		Version version = new Version("some-id", null);
+
+		assertEquals("some-id", version.getId());
+		assertNull(version.getParent());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testThatReLinkingParentThrowsException() {
+		Version parent = Version.rootVersion();
+		Version version = new Version("some-id", parent);
+		version.linkToParent(new Version("some-other-id", null));
+	}
+
+	@Test
+	public void testApplyMethod() {
+		Version parent = Version.rootVersion();
+
+		SchemaOperation operation = SchemaOperations.dropTable("users");
+		ChangeSet changeSet = new ChangeSet(operation);
+		Version newVersion = parent.apply(operation, changeSet);
+
+		assertNotNull(newVersion.getId());
+		assertEquals(parent, newVersion.getParent());
+		assertNull(newVersion.getChild());
+		assertEquals(newVersion, parent.getChild());
+		assertEquals(operation, newVersion.getSchemaOperation());
+		assertEquals(changeSet, newVersion.getChangeSet());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testApplyMethodWithNullInputForOperation() {
+		Version parent = Version.rootVersion();
+
+		SchemaOperation operation = SchemaOperations.dropTable("users");
+		ChangeSet changeSet = new ChangeSet(operation);
+		parent.apply(null, changeSet);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testApplyMethodWithNullInputForChangeSet() {
+		Version parent = Version.rootVersion();
+
+		SchemaOperation operation = SchemaOperations.dropTable("users");
+		parent.apply(operation, null);
+	}
+
+}


### PR DESCRIPTION
It is now possible to define a linear version history of SchemaOperation objects. Here's an example:

``` java
Changelog changelog = new Changelog();

changelog.addChangeSet("Create initial tables.",
        createTable("accounts")
            .with("id", int8(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
            .with("name", varchar(255), NOT_NULL)
            .with("credit", int8(), "'0'", NOT_NULL),
        createTable("transactions")
            .with("id", int8(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
            .with("from_id", int8(), NOT_NULL)
            .with("to_id", int8(), NOT_NULL)
            .with("amount", int8()));

changelog.addChangeSet("Add 'blocked' flag for 'accounts' table.",
        addColumn("accounts", "blocked", bool(), "'false'", NOT_NULL));

changelog.addChangeSet("Add 'processed' flag for 'transactions' table.",
        addColumn("transactions", "processed", bool(), "'false'", NOT_NULL));
```

Descriptions for ChangeSets are optional, and each ChangeSet can contain one or more SchemaOperation objects. The Changelog object also exposes the root Version object and the most recently added Version object (which map to the SchemaOperations as defined in the ChangeSets) through getter methods.
