### PR TITLE
Added a rename-table test case.

### DIFF
--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/Test.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/Test.java
@@ -35,7 +35,7 @@ public class Test {
 		Catalog catalog = state.getCatalog();
 		TableMapping mapping = state.getTableMapping();
 		for (Table table : catalog.getTables()) {
-			mapping.set(changelog.getRoot(), table.getName(), table.getName());
+			mapping.add(changelog.getRoot(), table.getName(), table.getName());
 		}
 
 		// Add schema change.

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CopyTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CopyTableMigrator.java
@@ -36,8 +36,7 @@ class CopyTableMigrator implements SchemaOperationMigrator<CopyTable> {
 		}
 
 		catalog.addTable(copy);
-		tableMapping.remove(version, sourceTableName);
-		tableMapping.set(version, targetTableName, tableId);
+		tableMapping.copy(version, sourceTableName, targetTableName, tableId);
 
 		// TODO: Add pipeline mappings...
 	}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CreateTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CreateTableMigrator.java
@@ -16,7 +16,7 @@ class CreateTableMigrator implements SchemaOperationMigrator<CreateTable> {
 		String tableName = operation.getTableName();
 
 		tableMapping.copyMappingFromParent(version);
-		tableMapping.set(version, tableName, tableId);
+		tableMapping.add(version, tableName, tableId);
 		dataMappings.copy(version);
 
 		Table table = new Table(tableId);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropTableMigrator.java
@@ -1,9 +1,9 @@
 package io.quantumdb.core.migration.operations;
 
 import io.quantumdb.core.migration.utils.DataMappings;
-import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.operations.DropTable;
+import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.versioning.Version;
 
 public class DropTableMigrator implements SchemaOperationMigrator<DropTable> {
@@ -12,8 +12,8 @@ public class DropTableMigrator implements SchemaOperationMigrator<DropTable> {
 	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, DropTable operation) {
 		tableMapping.copyMappingFromParent(version);
 		String tableId = tableMapping.getTableId(version, operation.getTableName());
-		dataMappings.copy(version)
-				.drop(catalog.getTable(tableId));
+		dataMappings.copy(version).drop(catalog.getTable(tableId));
+		tableMapping.remove(version, operation.getTableName());
 	}
 
 	@Override

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/RenameTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/RenameTableMigrator.java
@@ -1,9 +1,9 @@
 package io.quantumdb.core.migration.operations;
 
 import io.quantumdb.core.migration.utils.DataMappings;
-import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.operations.RenameTable;
+import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.versioning.Version;
 
 /**
@@ -17,9 +17,7 @@ public class RenameTableMigrator implements SchemaOperationMigrator<RenameTable>
 		String targetTableName = operation.getNewTableName();
 
 		tableMapping.copyMappingFromParent(version);
-
-		tableMapping.remove(version, sourceTableName);
-		tableMapping.set(version, targetTableName, sourceTableName);
+		tableMapping.rename(version, sourceTableName, targetTableName);
 	}
 
 	@Override

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
@@ -35,7 +35,7 @@ class TransitiveTableMirrorer {
 			Table table = catalog.getTable(tableId);
 
 			String newTableId = RandomHasher.generateTableId(tableMapping);
-			tableMapping.set(version, tableName, newTableId);
+			tableMapping.ghost(version, tableName, newTableId);
 			catalog.addTable(table.copy()
 					.rename(newTableId));
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/TableMapping.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/TableMapping.java
@@ -2,29 +2,54 @@ package io.quantumdb.core.versioning;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.RowSortedTable;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table.Cell;
 import com.google.common.collect.TreeBasedTable;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.Table;
+import lombok.Data;
 
 public class TableMapping {
+
+	@Data
+	static class TableMappingNode {
+
+		TableMappingNode(String tableId, String... basedOnTableIds) {
+			this.tableId = tableId;
+			this.basedOnTableIds = Sets.newHashSet(basedOnTableIds);
+		}
+
+		TableMappingNode(String tableId, Collection<String> basedOnTableIds) {
+			this.tableId = tableId;
+			this.basedOnTableIds = Sets.newHashSet(basedOnTableIds);
+		}
+
+		private final String tableId;
+		private final Set<String> basedOnTableIds;
+	}
 
 	public static TableMapping bootstrap(Version version, Catalog catalog) {
 		TableMapping mapping = new TableMapping();
 		for (Table table : catalog.getTables()) {
-			mapping.set(version, table.getName(), table.getName());
+			mapping.add(version, table.getName(), table.getName());
 		}
 		return mapping;
 	}
 
-	private final RowSortedTable<Version, String, String> versionMapping;
+	private final RowSortedTable<Version, String, TableMappingNode> versionMapping;
 
 	public TableMapping() {
 		this.versionMapping = TreeBasedTable.create();
@@ -32,34 +57,56 @@ public class TableMapping {
 
 	public TableMapping copyMappingFromParent(Version version) {
 		if (version.getParent() != null && versionMapping.containsRow(version.getParent())) {
-			Map<String, String> mapping = versionMapping.row(version.getParent());
-			for (Map.Entry<String, String> entry : mapping.entrySet()) {
+			Map<String, TableMappingNode> mapping = versionMapping.row(version.getParent());
+			for (Map.Entry<String, TableMappingNode> entry : mapping.entrySet()) {
 				versionMapping.put(version, entry.getKey(), entry.getValue());
 			}
 		}
 		return this;
 	}
 
-	public TableMapping set(Version version, String tableName, String alias) {
-		versionMapping.put(version, tableName, alias);
+	public TableMapping add(Version version, String tableName, String tableId) {
+		versionMapping.put(version, tableName, new TableMappingNode(tableId));
+		return this;
+	}
+
+	public TableMapping rename(Version version, String oldTableName, String newTableName) {
+		TableMappingNode node = removeInternally(version, oldTableName);
+		versionMapping.put(version, newTableName, node);
+		return this;
+	}
+
+	public TableMapping copy(Version version, String sourceTableName, String newTableName, String newTableId) {
+		TableMappingNode node = versionMapping.get(version, sourceTableName);
+		versionMapping.put(version, newTableName, new TableMappingNode(newTableId, node.getTableId()));
+		return this;
+	}
+
+	public TableMapping ghost(Version version, String tableName, String newTableId) {
+		TableMappingNode node = removeInternally(version, tableName);
+		Set<String> basedOnTableIds = Sets.newHashSet(node.getBasedOnTableIds());
+		if (basedOnTableIds.isEmpty()) {
+			basedOnTableIds.add(node.getTableId());
+		}
+		versionMapping.put(version, tableName, new TableMappingNode(newTableId, basedOnTableIds));
 		return this;
 	}
 
 	public String getTableId(Version version, String tableName) {
-		String tableId = versionMapping.get(version, tableName);
-		checkArgument(tableId != null, "Cannot find a tableId for tableName: "
+		String tableId = versionMapping.get(version, tableName).getTableId();
+		checkArgument(tableId != null, "Cannot find a tableId for tableId: "
 				+ tableName + " at version: " + version);
 		return tableId;
 	}
 
 	public String getTableName(Version version, String tableId) {
-		Map<String, String> mapping = versionMapping.row(version);
-		for (Map.Entry<String, String> entry : mapping.entrySet()) {
-			if (entry.getValue().equals(tableId)) {
+		Map<String, TableMappingNode> mapping = versionMapping.row(version);
+		for (Map.Entry<String, TableMappingNode> entry : mapping.entrySet()) {
+			if (entry.getValue().getTableId().equals(tableId)) {
 				return entry.getKey();
 			}
 		}
-		throw new IllegalArgumentException("Cannot find a tableName for tableId: "
+		throw new IllegalArgumentException("Cannot find a tableId for tableId: "
 				+ tableId + " at version: " + version + " - mapping was: " + mapping);
 	}
 
@@ -68,11 +115,15 @@ public class TableMapping {
 	}
 
 	public ImmutableSet<String> getTableIds() {
-		return ImmutableSet.copyOf(versionMapping.values());
+		return ImmutableSet.copyOf(versionMapping.values().stream()
+				.map(TableMappingNode::getTableId)
+				.collect(Collectors.toSet()));
 	}
 
 	public ImmutableSet<String> getTableIds(Version version) {
-		return ImmutableSet.copyOf(versionMapping.row(version).values());
+		return ImmutableSet.copyOf(versionMapping.row(version).values().stream()
+				.map(TableMappingNode::getTableId)
+				.collect(Collectors.toSet()));
 	}
 
 	public ImmutableSet<String> getTableNames(Version version) {
@@ -81,8 +132,8 @@ public class TableMapping {
 
 	public Optional<String> getTableName(String referencingTableId) {
 		return versionMapping.cellSet().stream()
-				.filter(entry -> referencingTableId.equals(entry.getValue()))
-				.map(entry -> entry.getColumnKey())
+				.filter(entry -> referencingTableId.equals(entry.getValue().getTableId()))
+				.map(Cell::getColumnKey)
 				.findFirst();
 	}
 
@@ -93,6 +144,27 @@ public class TableMapping {
 	}
 
 	public String remove(Version version, String tableName) {
+		return removeInternally(version, tableName).getTableId();
+	}
+
+	TableMappingNode removeInternally(Version version, String tableName) {
 		return versionMapping.remove(version, tableName);
 	}
+
+	public Multimap<String, String> getGhostTableIdMapping(Version source, Version target) {
+		Multimap<String, String> ghosts = HashMultimap.create();
+
+		ImmutableSet<String> tableIds = getTableIds(source);
+		for (TableMappingNode node : versionMapping.row(target).values()) {
+			if (tableIds.contains(node.getTableId())) {
+				continue;
+			}
+			if (node.getBasedOnTableIds() != null && tableIds.containsAll(node.getBasedOnTableIds())) {
+				node.getBasedOnTableIds().forEach(tableId -> ghosts.put(tableId, node.getTableId()));
+			}
+		}
+
+		return ghosts;
+	}
+
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/TableNameMappingBackend.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/TableNameMappingBackend.java
@@ -40,7 +40,9 @@ public class TableNameMappingBackend {
 					String tableId = mapping.getTableId();
 
 					Version version = changelog.getVersion(versionId);
-					tableMapping.set(version, tableName, tableId);
+
+					// TODO: Also store and retrieve the "based on" table Ids for each individual mapping.
+					tableMapping.add(version, tableName, tableId);
 				});
 
 		return tableMapping;

--- a/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/videostores/AddColumnToCustomersTable.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/videostores/AddColumnToCustomersTable.java
@@ -58,7 +58,7 @@ public class AddColumnToCustomersTable {
 	 * There should be no foreign key linking tables from the old schema to the new schema or vice-versa.
 	 */
 	@Test
-	public void verifyStoresTableStructure() {
+	public void verifyTableStructure() {
 		TableMapping mapping = state.getTableMapping();
 
 		// Original tables and foreign keys.
@@ -203,8 +203,10 @@ public class AddColumnToCustomersTable {
 		Set<String> targetTableIds = tableMapping.getTableIds(target);
 
 		Set<String> expectedOriginTableIds = Sets.newHashSet(
-				"stores", "staff", "customers", "films",
-				"inventory", "paychecks", "payments", "rentals");
+				PostgresqlBaseScenario.STORES_ID, PostgresqlBaseScenario.STAFF_ID,
+				PostgresqlBaseScenario.CUSTOMERS_ID, PostgresqlBaseScenario.FILMS_ID,
+				PostgresqlBaseScenario.INVENTORY_ID, PostgresqlBaseScenario.PAYCHECKS_ID,
+				PostgresqlBaseScenario.PAYMENTS_ID, PostgresqlBaseScenario.RENTALS_ID);
 
 		Set<String> expectedTargetTableIds = expectedOriginTableIds.stream()
 				.map(tableId -> {

--- a/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/videostores/RenameCustomersTable.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/videostores/RenameCustomersTable.java
@@ -7,85 +7,92 @@ import static io.quantumdb.core.backends.postgresql.PostgresTypes.varchar;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
 import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
+import static org.junit.Assert.assertEquals;
 
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import io.quantumdb.core.backends.Backend;
 import io.quantumdb.core.backends.DatabaseMigrator.MigrationException;
-import io.quantumdb.core.backends.guice.PersistenceModule;
-import io.quantumdb.core.backends.postgresql.PostgresqlDatabase;
-import io.quantumdb.core.backends.postgresql.migrator.TableCreator;
-import io.quantumdb.core.migration.Migrator;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.Column;
 import io.quantumdb.core.schema.definitions.Table;
-import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.schema.operations.SchemaOperations;
 import io.quantumdb.core.versioning.State;
 import io.quantumdb.core.versioning.TableMapping;
-import lombok.Getter;
+import io.quantumdb.core.versioning.Version;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 
-@Getter
-public class PostgresqlBaseScenario extends PostgresqlDatabase {
+public class RenameCustomersTable {
 
-	public static final String STORES_ID = "table_8e7f3e2bff";
-	public static final String STAFF_ID = "table_0bc1cb405a";
-	public static final String CUSTOMERS_ID = "table_c5d814a492";
-	public static final String FILMS_ID = "table_9fc422e0a8";
-	public static final String INVENTORY_ID = "table_61a6a2518f";
-	public static final String PAYCHECKS_ID = "table_08f08c873f";
-	public static final String PAYMENTS_ID = "table_9859d9b73f";
-	public static final String RENTALS_ID = "table_d9cabab994";
+	@ClassRule
+	public static PostgresqlBaseScenario setup = new PostgresqlBaseScenario();
 
-	private Backend backend;
-	private Catalog catalog;
-	private Migrator migrator;
-	private Injector injector;
-	private Changelog changelog;
-	private TableMapping tableMapping;
-	private State state;
+	private static State state;
+	private static Version origin;
+	private static Version target;
 
-	@Override
-	public void before() throws SQLException, MigrationException, ClassNotFoundException {
-		super.before();
+	@BeforeClass
+	public static void performEvolution() throws SQLException, MigrationException {
+		origin = setup.getChangelog().getLastAdded();
 
-		TableCreator tableCreator = new TableCreator();
+		setup.getChangelog().addChangeSet("Michael de Jong",
+				SchemaOperations.renameTable("customers", "clients"));
 
-		Table stores = new Table(STORES_ID)
+		target = setup.getChangelog().getLastAdded();
+		setup.getBackend().persistState(setup.getState());
+
+		setup.getMigrator().migrate(origin.getId(), target.getId());
+
+		state = setup.getBackend().loadState();
+	}
+
+	/*
+	 * Using the expansive method of forking the schema, this test should result in two completely separated
+	 * database schemas. The schema associated with the original version, should contain all original tables,
+	 * while the schema associated with the new version, should contain ghost tables of all original tables.
+	 * There should be no foreign key linking tables from the old schema to the new schema or vice-versa.
+	 */
+	@Test
+	public void verifyTableStructure() {
+		TableMapping mapping = state.getTableMapping();
+
+		Table stores = new Table(mapping.getTableId(origin, "stores"))
 				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
-		Table staff = new Table(STAFF_ID)
+		Table staff = new Table(mapping.getTableId(origin, "staff"))
 				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
-		Table customers = new Table(CUSTOMERS_ID)
+		Table customers = new Table(mapping.getTableId(origin, "customers"))
 				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
-		Table films = new Table(FILMS_ID)
+		Table films = new Table(mapping.getTableId(origin, "films"))
 				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
-		Table inventory = new Table(INVENTORY_ID)
+		Table inventory = new Table(mapping.getTableId(origin, "inventory"))
 				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
-		Table paychecks = new Table(PAYCHECKS_ID)
+		Table paychecks = new Table(mapping.getTableId(origin, "paychecks"))
 				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
-		Table payments = new Table(PAYMENTS_ID)
+		Table payments = new Table(mapping.getTableId(origin, "payments"))
 				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
@@ -93,7 +100,7 @@ public class PostgresqlBaseScenario extends PostgresqlDatabase {
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
-		Table rentals = new Table(RENTALS_ID)
+		Table rentals = new Table(mapping.getTableId(origin, "rentals"))
 				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
@@ -101,58 +108,58 @@ public class PostgresqlBaseScenario extends PostgresqlDatabase {
 				.addColumn(new Column("date", date(), NOT_NULL));
 
 		stores.addForeignKey("manager_id").referencing(staff, "id");
-
 		staff.addForeignKey("store_id").referencing(stores, "id");
-
 		customers.addForeignKey("referred_by").referencing(customers, "id");
 		customers.addForeignKey("store_id").referencing(stores, "id");
-
 		inventory.addForeignKey("store_id").referencing(stores, "id");
 		inventory.addForeignKey("film_id").referencing(films, "id");
-
 		paychecks.addForeignKey("staff_id").referencing(staff, "id");
-
 		payments.addForeignKey("staff_id").referencing(staff, "id");
 		payments.addForeignKey("customer_id").referencing(customers, "id");
 		payments.addForeignKey("rental_id").referencing(rentals, "id");
-
 		rentals.addForeignKey("staff_id").referencing(staff, "id");
 		rentals.addForeignKey("customer_id").referencing(customers, "id");
 		rentals.addForeignKey("inventory_id").referencing(inventory, "id");
 
 		Set<Table> tables = Sets.newHashSet(stores, staff, customers, films, inventory, paychecks, payments, rentals);
 
-		catalog = new Catalog(getCatalogName());
-		tables.forEach(catalog::addTable);
+		Catalog expected = new Catalog(setup.getCatalogName());
+		tables.forEach(expected::addTable);
 
-		tableCreator.create(getConnection(), tables);
+		assertEquals(expected.getTables(), state.getCatalog().getTables());
+	}
 
-		String jdbcUrl = getJdbcUrl();
-		String catalogName = getCatalogName();
-		String jdbcUser = getJdbcUser();
-		String jdbcPass = getJdbcPass();
-		PersistenceModule module = new PersistenceModule(jdbcUrl, catalogName, jdbcUser, jdbcPass);
+	@Test
+	public void verifyTableMappings() {
+		TableMapping tableMapping = state.getTableMapping();
 
-		injector = Guice.createInjector(module);
-		backend = injector.getInstance(Backend.class);
+		Map<String, String> originTableIds = tableMapping.getTableMapping(origin);
+		Map<String, String> targetTableIds = tableMapping.getTableMapping(target);
 
-		state = backend.loadState();
-		changelog = state.getChangelog();
+		Map<String, String> expectedOriginTableIds = ImmutableMap.<String, String>builder()
+				.put(PostgresqlBaseScenario.STORES_ID, "stores")
+				.put(PostgresqlBaseScenario.STAFF_ID, "staff")
+				.put(PostgresqlBaseScenario.CUSTOMERS_ID, "customers")
+				.put(PostgresqlBaseScenario.FILMS_ID, "films")
+				.put(PostgresqlBaseScenario.INVENTORY_ID, "inventory")
+				.put(PostgresqlBaseScenario.PAYCHECKS_ID, "paychecks")
+				.put(PostgresqlBaseScenario.PAYMENTS_ID, "payments")
+				.put(PostgresqlBaseScenario.RENTALS_ID, "rentals")
+				.build();
 
-		// Register pre-existing tables in root version.
-		catalog = state.getCatalog();
-		tableMapping = state.getTableMapping();
-		tableMapping.add(changelog.getRoot(), "stores", STORES_ID);
-		tableMapping.add(changelog.getRoot(), "staff", STAFF_ID);
-		tableMapping.add(changelog.getRoot(), "customers", CUSTOMERS_ID);
-		tableMapping.add(changelog.getRoot(), "films", FILMS_ID);
-		tableMapping.add(changelog.getRoot(), "inventory", INVENTORY_ID);
-		tableMapping.add(changelog.getRoot(), "paychecks", PAYCHECKS_ID);
-		tableMapping.add(changelog.getRoot(), "payments", PAYMENTS_ID);
-		tableMapping.add(changelog.getRoot(), "rentals", RENTALS_ID);
+		Map<String, String>expectedTargetTableIds = ImmutableMap.<String, String>builder()
+				.put(PostgresqlBaseScenario.STORES_ID, "stores")
+				.put(PostgresqlBaseScenario.STAFF_ID, "staff")
+				.put(PostgresqlBaseScenario.CUSTOMERS_ID, "clients")
+				.put(PostgresqlBaseScenario.FILMS_ID, "films")
+				.put(PostgresqlBaseScenario.INVENTORY_ID, "inventory")
+				.put(PostgresqlBaseScenario.PAYCHECKS_ID, "paychecks")
+				.put(PostgresqlBaseScenario.PAYMENTS_ID, "payments")
+				.put(PostgresqlBaseScenario.RENTALS_ID, "rentals")
+				.build();
 
-		backend.persistState(state);
-		migrator = injector.getInstance(Migrator.class);
+		assertEquals(expectedOriginTableIds, originTableIds);
+		assertEquals(expectedTargetTableIds, targetTableIds);
 	}
 
 }

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropTableMigratorTest.java
@@ -48,7 +48,7 @@ public class DropTableMigratorTest {
 		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		assertEquals(1, catalog.getTables().size());
-		assertFalse(!tableMapping.getTableIds(changelog.getLastAdded()).contains("users"));
+		assertFalse(tableMapping.getTableIds(changelog.getLastAdded()).contains("users"));
 	}
 
 }

--- a/quantumdb-core/src/test/java/io/quantumdb/core/utils/RandomHasherTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/utils/RandomHasherTest.java
@@ -39,7 +39,7 @@ public class RandomHasherTest {
 	public void testGeneratingUniqueTableIdWithFilledTableMapping() {
 		TableMapping tableMapping = new TableMapping();
 		Version version = new Version(RandomHasher.generateHash(), null);
-		tableMapping.set(version, "users", "users");
+		tableMapping.add(version, "users", "users");
 
 		String tableId = RandomHasher.generateTableId(tableMapping);
 		assertFalse(isNullOrEmpty(tableId));

--- a/quantumdb-core/src/test/java/io/quantumdb/core/versioning/TableMappingTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/versioning/TableMappingTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Sets;
 import io.quantumdb.core.utils.RandomHasher;
-import io.quantumdb.core.versioning.TableMapping;
-import io.quantumdb.core.versioning.Version;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,7 +29,7 @@ public class TableMappingTest {
 		String tableName = "users";
 		String alias = RandomHasher.generateHash();
 
-		tableMapping.set(version, tableName, alias);
+		tableMapping.add(version, tableName, alias);
 
 		assertEquals(alias, tableMapping.getTableId(version, tableName));
 		assertEquals(tableName, tableMapping.getTableName(version, alias));
@@ -44,7 +42,7 @@ public class TableMappingTest {
 		String alias = RandomHasher.generateHash();
 
 		Version version = new Version(RandomHasher.generateHash(), null);
-		tableMapping.set(version, tableName, alias);
+		tableMapping.add(version, tableName, alias);
 
 		Version child = new Version(RandomHasher.generateHash(), version);
 		tableMapping.copyMappingFromParent(child);


### PR DESCRIPTION
This PR adds a rename-table test for the video stores test scenario.

* In order to track renames in the `TableMapping` class, we keep track of the origin of a mapping.
* Additional methods have been added to the `TableMapping` class with different intentions.
* Currently this table rename tracking is not persisted or loaded from the database. This will need to be fixed in the future, if this proves to be a suitable solution.