### PR TITLE
Store the chosen database schema version of the client in the application_name

### DIFF
--- a/quantumdb-driver/src/main/java/io/quantumdb/driver/Driver.java
+++ b/quantumdb-driver/src/main/java/io/quantumdb/driver/Driver.java
@@ -41,6 +41,17 @@ public class Driver implements java.sql.Driver {
 		}
 
 		String version = parseVersion(url);
+		if (version != null) {
+			String applicationName = info.getProperty("ApplicationName");
+			if (applicationName != null && !applicationName.equals("")) {
+				applicationName += " - " + version;
+			}
+			else {
+				applicationName = version;
+			}
+			info.setProperty("ApplicationName", applicationName);
+		}
+
 		this.delegate = DriverManager.getDriver(url);
 		Connection connection = delegate.connect(url, info);
 		QueryRewriter queryRewriter = new PostgresqlQueryRewriter(true);


### PR DESCRIPTION
This PR ensure that the driver stores the chosen database schema version into the `application_name` field (PostgreSQL) which should allow us in the future to detect which clients are connected using which specific version of the database schema.