### PR TITLE
Rename expand method to migrate in SchemaOperationMigrator

### DIFF
--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/postgresql/planner/ExpansiveMigrationPlanner.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/postgresql/planner/ExpansiveMigrationPlanner.java
@@ -41,7 +41,7 @@ public class ExpansiveMigrationPlanner implements MigrationPlanner {
 		migrationPath.remove(from);
 		migrationPath.stream()
 				.filter(version -> version.getParent() != null)
-				.forEachOrdered(version -> migrator.expand(version, version.getSchemaOperation()));
+				.forEachOrdered(version -> migrator.migrate(version, version.getSchemaOperation()));
 
 		Set<String> preTableIds = tableMapping.getTableIds(from);
 		Set<String> postTableIds = tableMapping.getTableIds(to);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import io.quantumdb.core.backends.Backend;
-import io.quantumdb.core.backends.DatabaseMigrator;
+import io.quantumdb.core.backends.DatabaseMigrator.MigrationException;
 import io.quantumdb.core.migration.utils.VersionTraverser;
 import io.quantumdb.core.versioning.Changelog;
 import io.quantumdb.core.versioning.State;
@@ -27,7 +27,7 @@ public class Migrator {
 		this.backend = backend;
 	}
 
-	public void migrate(String sourceVersionId, String targetVersionId) throws DatabaseMigrator.MigrationException {
+	public void migrate(String sourceVersionId, String targetVersionId) throws MigrationException {
 		log.info("Migrating database structure from version: {} to version: {}", sourceVersionId, targetVersionId);
 
 		State state = loadState();
@@ -60,12 +60,12 @@ public class Migrator {
 		backend.getMigrator().migrate(state, from, to);
 	}
 
-	private State loadState() throws DatabaseMigrator.MigrationException {
+	private State loadState() throws MigrationException {
 		try {
 			return backend.loadState();
 		}
 		catch (SQLException e) {
-			throw new DatabaseMigrator.MigrationException("Could not load current state: " + e.getMessage(), e);
+			throw new MigrationException("Could not load current state: " + e.getMessage(), e);
 		}
 	}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddColumnMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddColumnMigrator.java
@@ -12,7 +12,8 @@ import lombok.NoArgsConstructor;
 class AddColumnMigrator implements SchemaOperationMigrator<AddColumn> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, AddColumn operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			AddColumn operation) {
 		String tableName = operation.getTableName();
 		TransitiveTableMirrorer.mirror(catalog, tableMapping, version, tableName);
 		dataMappings.copy(version);
@@ -20,11 +21,6 @@ class AddColumnMigrator implements SchemaOperationMigrator<AddColumn> {
 		String tableId = tableMapping.getTableId(version, tableName);
 		catalog.getTable(tableId)
 				.addColumn(operation.getColumnDefinition().createColumn());
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, AddColumn operation) {
-		throw new UnsupportedOperationException();
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddForeignKeyMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddForeignKeyMigrator.java
@@ -1,16 +1,17 @@
 package io.quantumdb.core.migration.operations;
 
 import io.quantumdb.core.migration.utils.DataMappings;
-import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.Table;
 import io.quantumdb.core.schema.operations.AddForeignKey;
+import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.versioning.Version;
 
 class AddForeignKeyMigrator implements SchemaOperationMigrator<AddForeignKey> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, AddForeignKey operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			AddForeignKey operation) {
 		String tableName = operation.getReferringTableName();
 		TransitiveTableMirrorer.mirror(catalog, tableMapping, version, tableName);
 		dataMappings.copy(version);
@@ -24,11 +25,6 @@ class AddForeignKeyMigrator implements SchemaOperationMigrator<AddForeignKey> {
 
 		table.addForeignKey(operation.getReferringColumnNames())
 				.referencing(referencedTable, operation.getReferencedColumnNames());
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, AddForeignKey operation) {
-		throw new UnsupportedOperationException();
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AlterColumnMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AlterColumnMigrator.java
@@ -4,16 +4,18 @@ import java.util.Optional;
 
 import com.google.common.base.Strings;
 import io.quantumdb.core.migration.utils.DataMappings;
-import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.Column;
 import io.quantumdb.core.schema.operations.AlterColumn;
+import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.versioning.Version;
 
 class AlterColumnMigrator implements SchemaOperationMigrator<AlterColumn> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, AlterColumn operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			AlterColumn operation) {
+
 		String tableName = operation.getTableName();
 		TransitiveTableMirrorer.mirror(catalog, tableMapping, version, tableName);
 		dataMappings.copy(version);
@@ -48,11 +50,6 @@ class AlterColumnMigrator implements SchemaOperationMigrator<AlterColumn> {
 		}
 
 		// TODO: replace pipeline with correct transformation
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, AlterColumn operation) {
-		throw new UnsupportedOperationException();
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CopyTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CopyTableMigrator.java
@@ -12,7 +12,8 @@ import io.quantumdb.core.versioning.Version;
 class CopyTableMigrator implements SchemaOperationMigrator<CopyTable> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, CopyTable operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			CopyTable operation) {
 		String tableId = RandomHasher.generateTableId(tableMapping);
 		String sourceTableName = operation.getSourceTableName();
 		String targetTableName = operation.getTargetTableName();
@@ -40,11 +41,6 @@ class CopyTableMigrator implements SchemaOperationMigrator<CopyTable> {
 		tableMapping.copy(version, sourceTableName, targetTableName, tableId);
 
 		// TODO: Add pipeline mappings...
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, CopyTable operation) {
-		throw new UnsupportedOperationException();
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CreateTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CreateTableMigrator.java
@@ -1,17 +1,18 @@
 package io.quantumdb.core.migration.operations;
 
 import io.quantumdb.core.migration.utils.DataMappings;
-import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.Table;
 import io.quantumdb.core.schema.operations.CreateTable;
 import io.quantumdb.core.utils.RandomHasher;
+import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.versioning.Version;
 
 class CreateTableMigrator implements SchemaOperationMigrator<CreateTable> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, CreateTable operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			CreateTable operation) {
 		String tableId = RandomHasher.generateTableId(tableMapping);
 		String tableName = operation.getTableName();
 
@@ -24,11 +25,6 @@ class CreateTableMigrator implements SchemaOperationMigrator<CreateTable> {
 				.forEachOrdered(c -> table.addColumn(c.createColumn()));
 
 		catalog.addTable(table);
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, CreateTable operation) {
-		throw new UnsupportedOperationException();
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropColumnMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropColumnMigrator.java
@@ -1,16 +1,17 @@
 package io.quantumdb.core.migration.operations;
 
 import io.quantumdb.core.migration.utils.DataMappings;
-import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.Table;
 import io.quantumdb.core.schema.operations.DropColumn;
+import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.versioning.Version;
 
 class DropColumnMigrator implements SchemaOperationMigrator<DropColumn> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, DropColumn operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			DropColumn operation) {
 		String tableName = operation.getTableName();
 		TransitiveTableMirrorer.mirror(catalog, tableMapping, version, tableName);
 
@@ -20,11 +21,6 @@ class DropColumnMigrator implements SchemaOperationMigrator<DropColumn> {
 				.drop(table, operation.getColumnName());
 
 		table.removeColumn(operation.getColumnName());
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, DropColumn operation) {
-		throw new UnsupportedOperationException();
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropForeignKeyMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropForeignKeyMigrator.java
@@ -1,7 +1,8 @@
 package io.quantumdb.core.migration.operations;
 
+import java.util.List;
+
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import io.quantumdb.core.migration.utils.DataMappings;
 import io.quantumdb.core.schema.definitions.Catalog;
@@ -14,7 +15,8 @@ import io.quantumdb.core.versioning.Version;
 class DropForeignKeyMigrator implements SchemaOperationMigrator<DropForeignKey> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, DropForeignKey operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			DropForeignKey operation) {
 		String tableName = operation.getTableName();
 		TransitiveTableMirrorer.mirror(catalog, tableMapping, version, tableName);
 		dataMappings.copy(version);
@@ -24,7 +26,7 @@ class DropForeignKeyMigrator implements SchemaOperationMigrator<DropForeignKey> 
 
 		ForeignKey matchedForeignKey = table.getForeignKeys().stream()
 				.filter(foreignKey -> {
-					ImmutableList<String> referencingColumns = foreignKey.getReferencingColumns();
+					List<String> referencingColumns = foreignKey.getReferencingColumns();
 					return referencingColumns.containsAll(Sets.newHashSet(operation.getReferringColumnNames()));
 				})
 				.findFirst()
@@ -32,11 +34,6 @@ class DropForeignKeyMigrator implements SchemaOperationMigrator<DropForeignKey> 
 						+ " for the column(s): " + Joiner.on(", ").join(operation.getReferringColumnNames())));
 
 		matchedForeignKey.drop();
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, DropForeignKey operation) {
-		throw new UnsupportedOperationException();
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropTableMigrator.java
@@ -9,16 +9,12 @@ import io.quantumdb.core.versioning.Version;
 public class DropTableMigrator implements SchemaOperationMigrator<DropTable> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, DropTable operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			DropTable operation) {
 		tableMapping.copyMappingFromParent(version);
 		String tableId = tableMapping.getTableId(version, operation.getTableName());
 		dataMappings.copy(version).drop(catalog.getTable(tableId));
 		tableMapping.remove(version, operation.getTableName());
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, DropTable operation) {
-
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/JoinTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/JoinTableMigrator.java
@@ -14,7 +14,8 @@ import io.quantumdb.core.versioning.Version;
 class JoinTableMigrator implements SchemaOperationMigrator<JoinTable> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, JoinTable operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			JoinTable operation) {
 		String targetTableId = RandomHasher.generateTableId(tableMapping);
 		String targetTableName = operation.getTargetTableName();
 
@@ -38,11 +39,6 @@ class JoinTableMigrator implements SchemaOperationMigrator<JoinTable> {
 		});
 
 		catalog.addTable(targetTable);
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, JoinTable operation) {
-		throw new UnsupportedOperationException();
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/RenameTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/RenameTableMigrator.java
@@ -6,23 +6,16 @@ import io.quantumdb.core.schema.operations.RenameTable;
 import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.versioning.Version;
 
-/**
- * TODO: We don't actually rename tables. We just manipulate the table mapping... Should we "fix" this?
- */
 public class RenameTableMigrator implements SchemaOperationMigrator<RenameTable> {
 
 	@Override
-	public void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, RenameTable operation) {
+	public void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version,
+			RenameTable operation) {
 		String sourceTableName = operation.getTableName();
 		String targetTableName = operation.getNewTableName();
 
 		tableMapping.copyMappingFromParent(version);
 		tableMapping.rename(version, sourceTableName, targetTableName);
-	}
-
-	@Override
-	public void contract(Catalog catalog, TableMapping tableMapping, Version version, RenameTable operation) {
-		// Do nothing...
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/SchemaOperationMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/SchemaOperationMigrator.java
@@ -1,15 +1,13 @@
 package io.quantumdb.core.migration.operations;
 
 import io.quantumdb.core.migration.utils.DataMappings;
-import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.operations.SchemaOperation;
+import io.quantumdb.core.versioning.TableMapping;
 import io.quantumdb.core.versioning.Version;
 
 interface SchemaOperationMigrator<T extends SchemaOperation> {
 
-	void expand(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, T operation);
-
-	void contract(Catalog catalog, TableMapping tableMapping, Version version, T operation);
+	void migrate(Catalog catalog, TableMapping tableMapping, DataMappings dataMappings, Version version, T operation);
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/SchemaOperationsMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/SchemaOperationsMigrator.java
@@ -48,13 +48,13 @@ public class SchemaOperationsMigrator {
 		return dataMappings;
 	}
 
-	public <T extends SchemaOperation> void expand(Version version, T operation) {
+	public <T extends SchemaOperation> void migrate(Version version, T operation) {
 		Class<?> type = operation.getClass();
 		SchemaOperationMigrator<T> migrator = (SchemaOperationMigrator<T>) migrators.get(type);
 		if (migrator == null) {
 			throw new UnsupportedOperationException("The operation: " + type + " is not (yet) supported!");
 		}
-		migrator.expand(catalog, tableMapping, dataMappings, version, operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, version, operation);
 	}
 
 }

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddColumnMigratorTest.java
@@ -46,7 +46,7 @@ public class AddColumnMigratorTest {
 	public void testExpandForAddingSingleColumn() {
 		AddColumn operation = SchemaOperations.addColumn("users", "date_of_birth", date(), "NULL");
 		changelog.addChangeSet("Michael de Jong", "Added 'date_of_birth' column to 'users' table.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("users");
 		Table ghostTable = getGhostTable(originalTable);
@@ -63,11 +63,11 @@ public class AddColumnMigratorTest {
 	public void testExpandForAddingMultipleColumns() {
 		AddColumn operation1 = SchemaOperations.addColumn("users", "date_of_birth", date(), "NULL");
 		changelog.addChangeSet("Michael de Jong", "Added 'date_of_birth' column to 'users' table.", operation1);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation1);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation1);
 
 		AddColumn operation2 = SchemaOperations.addColumn("users", "activated", bool(), "TRUE");
 		changelog.addChangeSet("Michael de Jong", "Added 'activated' column to 'users' table.", operation2);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation2);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation2);
 
 		Table originalTable = catalog.getTable("users");
 		Table ghostTable = getGhostTable(originalTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddForeignKeyMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddForeignKeyMigratorTest.java
@@ -47,7 +47,7 @@ public class AddForeignKeyMigratorTest {
 	public void testExpandForAddingSingleColumn() {
 		AddForeignKey operation = SchemaOperations.addForeignKey("posts", "author").referencing("users", "id");
 		changelog.addChangeSet("Michael de Jong", "Added 'date_of_birth' column to 'users' table.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table usersTable = catalog.getTable("users");
 		Table originalTable = catalog.getTable("posts");

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AlterColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AlterColumnMigratorTest.java
@@ -49,7 +49,7 @@ public class AlterColumnMigratorTest {
 	public void testExpandForRenamingColumn() {
 		AlterColumn operation = SchemaOperations.alterColumn("users", "name").rename("full_name");
 		changelog.addChangeSet("Michael de Jong", "Renaming 'name' column to 'full_name' column.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("users");
 		Table ghostTable = getGhostTable(originalTable);
@@ -65,7 +65,7 @@ public class AlterColumnMigratorTest {
 	public void testExpandForChangingTypeOfColumn() {
 		AlterColumn operation = SchemaOperations.alterColumn("users", "name").modifyDataType(PostgresTypes.text());
 		changelog.addChangeSet("Michael de Jong", "Set type of 'name' column to 'text'.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("users");
 		Table ghostTable = getGhostTable(originalTable);
@@ -81,7 +81,7 @@ public class AlterColumnMigratorTest {
 	public void testExpandForSettingDefaultValue() {
 		AlterColumn operation = SchemaOperations.alterColumn("users", "name").modifyDefaultExpression("'Unknown'");
 		changelog.addChangeSet("Michael de Jong", "Set default of 'name' column to 'Unknown'.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("users");
 		Table ghostTable = getGhostTable(originalTable);
@@ -99,7 +99,7 @@ public class AlterColumnMigratorTest {
 
 		AlterColumn operation = SchemaOperations.alterColumn("users", "name").modifyDefaultExpression("'John Smith'");
 		changelog.addChangeSet("Michael de Jong", "Set default of 'name' column to 'John Smith'.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("users");
 		Table ghostTable = getGhostTable(originalTable);
@@ -117,7 +117,7 @@ public class AlterColumnMigratorTest {
 
 		AlterColumn operation = SchemaOperations.alterColumn("users", "name").dropDefaultExpression();
 		changelog.addChangeSet("Michael de Jong", "Set default of 'name' column to 'John Smith'.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("users");
 		Table ghostTable = getGhostTable(originalTable);
@@ -133,7 +133,7 @@ public class AlterColumnMigratorTest {
 	public void testExpandForAddingNotNullHint() {
 		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invited_by_id").addHint(NOT_NULL);
 		changelog.addChangeSet("Michael de Jong", "Added NOT_NULL constraint to 'invited_by_id' column.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
 		Table ghostTable = getGhostTable(originalTable);
@@ -149,7 +149,7 @@ public class AlterColumnMigratorTest {
 	public void testExpandForRemovingNotNullHint() {
 		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invitee_id").dropHint(NOT_NULL);
 		changelog.addChangeSet("Michael de Jong", "Dropped NOT_NULL constraint of 'invitee_id' column.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
 		Table ghostTable = getGhostTable(originalTable);
@@ -165,7 +165,7 @@ public class AlterColumnMigratorTest {
 	public void testExpandForAddingAutoIncrementHint() {
 		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invited_by_id").addHint(AUTO_INCREMENT);
 		changelog.addChangeSet("Michael de Jong", "Added AUTO_INCREMENT constraint to 'invited_by_id' column.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
 		Table ghostTable = getGhostTable(originalTable);
@@ -181,7 +181,7 @@ public class AlterColumnMigratorTest {
 	public void testExpandForRemovingAutoIncrementHint() {
 		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invitee_id").dropHint(AUTO_INCREMENT);
 		changelog.addChangeSet("Michael de Jong", "Dropped NOT_NULL constraint of 'invitee_id' column.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
 		Table ghostTable = getGhostTable(originalTable);
@@ -197,7 +197,7 @@ public class AlterColumnMigratorTest {
 	public void testExpandForAddingIdentityHint() {
 		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invited_by_id").addHint(IDENTITY);
 		changelog.addChangeSet("Michael de Jong", "Added IDENTITY constraint to 'invited_by_id' column.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
 		Table ghostTable = getGhostTable(originalTable);
@@ -215,7 +215,7 @@ public class AlterColumnMigratorTest {
 
 		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invitee_id").dropHint(IDENTITY);
 		changelog.addChangeSet("Michael de Jong", "Dropped IDENTITY constraint of 'invitee_id' column.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
 		Table ghostTable = getGhostTable(originalTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CopyTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CopyTableMigratorTest.java
@@ -48,7 +48,7 @@ public class CopyTableMigratorTest {
 	public void testExpandForCopyingTable() {
 		CopyTable operation = SchemaOperations.copyTable("users", "customers");
 		changelog.addChangeSet("Michael de Jong", "Copying 'users' table to 'customers'.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		String tableId = tableMapping.getTableId(changelog.getLastAdded(), "customers");
 		Table ghostTable = catalog.getTable(tableId);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CreateTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CreateTableMigratorTest.java
@@ -43,7 +43,7 @@ public class CreateTableMigratorTest {
 				.with("name", varchar(255), NOT_NULL);
 
 		changelog.addChangeSet("Michael de Jong", "Creating 'users' table.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		String tableId = tableMapping.getTableId(changelog.getLastAdded(), "users");
 		Table ghostTable = catalog.getTable(tableId);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropColumnMigratorTest.java
@@ -44,7 +44,7 @@ public class DropColumnMigratorTest {
 	public void testExpandForDroppingSingleColumn() {
 		DropColumn operation = SchemaOperations.dropColumn("users", "name");
 		changelog.addChangeSet("Michael de Jong", "Dropped 'name' column from 'users' table.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("users");
 		Table ghostTable = getGhostTable(originalTable);
@@ -59,7 +59,7 @@ public class DropColumnMigratorTest {
 	public void testExpandForDroppingIdentityColumn() {
 		DropColumn operation = SchemaOperations.dropColumn("users", "id");
 		changelog.addChangeSet("Michael de Jong", "Dropped 'id' column from 'users' table.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 	}
 
 	private Table getGhostTable(Table table) {

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropForeignKeyMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropForeignKeyMigratorTest.java
@@ -51,7 +51,7 @@ public class DropForeignKeyMigratorTest {
 	public void testExpandForDroppingForeignKey() {
 		DropForeignKey operation = dropForeignKey("posts", "author");
 		changelog.addChangeSet("Michael de Jong", "Drop author foreign key from posts table.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("posts");
 		Table ghostTable = getGhostTable(originalTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropTableMigratorTest.java
@@ -45,7 +45,7 @@ public class DropTableMigratorTest {
 	public void testExpandForDroppingTable() {
 		DropTable operation = SchemaOperations.dropTable("users");
 		changelog.addChangeSet("Michael de Jong", "Dropped 'users' table.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		assertEquals(1, catalog.getTables().size());
 		assertFalse(tableMapping.getTableIds(changelog.getLastAdded()).contains("users"));

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/RenameTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/RenameTableMigratorTest.java
@@ -45,7 +45,7 @@ public class RenameTableMigratorTest {
 	public void testExpandForRenamingTable() {
 		RenameTable operation = SchemaOperations.renameTable("users", "customers");
 		changelog.addChangeSet("Michael de Jong", "Renaming 'users' table to 'customers'.", operation);
-		migrator.expand(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
+		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 
 		String tableId = tableMapping.getTableId(changelog.getLastAdded(), "customers");
 		Table ghostTable = catalog.getTable(tableId);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/SchemaOperationInterpreterTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/SchemaOperationInterpreterTest.java
@@ -38,7 +38,7 @@ public class SchemaOperationInterpreterTest {
 						.with("id", bigint(), NOT_NULL, AUTO_INCREMENT, IDENTITY));
 
 		Version current = changelog.getLastAdded();
-		migrator.expand(current, current.getSchemaOperation());
+		migrator.migrate(current, current.getSchemaOperation());
 
 		String tableId = tableMapping.getTableId(current, "users");
 


### PR DESCRIPTION
In this PR, we rename the `expand` method in the `SchemaOperationMigrator` class to `migrate` to better reflect its purpose.