### PR TITLE
Multiple consecutive schema operations now result in correct DataMappings.

### DIFF
--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
@@ -42,9 +42,9 @@ class TransitiveTableMirrorer {
 			mirrored.add(tableName);
 
 			// Traverse incoming foreign keys
-			catalog.getTablesReferencingTable(tableId).stream()
-					.map(referencingTableId -> tableMapping.getTableName(parentVersion, referencingTableId))
-					.forEach(tablesToMirror::add);
+			for (String referencingTableId : catalog.getTablesReferencingTable(tableId)) {
+				tableMapping.getTableName(referencingTableId).ifPresent(tablesToMirror::add);
+			}
 		}
 
 		// Copying foreign keys for each affected table.

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/utils/DataMappings.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/utils/DataMappings.java
@@ -142,11 +142,14 @@ public class DataMappings {
 			processed.add(dataMapping);
 
 			Table sourceTable = dataMapping.getSourceTable();
+			Table targetTable = dataMapping.getTargetTable();
 			boolean isFirstDegreeMapping = sourceTable.equals(table);
 
 			DataMapping currentMapping = dataMapping;
 			if (!isFirstDegreeMapping) {
-				intermediateTables.add(sourceTable);
+				if (!sourceTable.equals(targetTable)) {
+					intermediateTables.add(sourceTable);
+				}
 				currentMapping = currentMappings.get(sourceTable);
 			}
 
@@ -180,7 +183,6 @@ public class DataMappings {
 				}
 			}
 
-			Table targetTable = dataMapping.getTargetTable();
 			getMappings(targetTable, direction).stream()
 					.filter(mapping -> !processed.contains(mapping))
 					.forEach(toProcess::add);


### PR DESCRIPTION
This fixes the problem that incorrect DataMapping instances were returned when executing the MigrationPlan, when multiple consecutive schema operations were involved.
