### PR TITLE
Add support for named foreign key operations.

### DIFF
--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/postgresql/planner/GreedyMigrationPlanner.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/postgresql/planner/GreedyMigrationPlanner.java
@@ -501,7 +501,12 @@ public class GreedyMigrationPlanner implements MigrationPlanner {
 						String referredTableName = tableMapping.getTableName(from, referredTableId);
 						String mappedTableId = tableMapping.getTableId(to, referredTableName);
 						Table referredTable = catalog.getTable(mappedTableId);
-						newTable.addForeignKey(fk.getReferencingColumns()).referencing(referredTable, fk.getReferredColumns());
+
+						newTable.addForeignKey(fk.getReferencingColumns())
+								.named(fk.getForeignKeyName())
+								.onUpdate(fk.getOnUpdate())
+								.onDelete(fk.getOnDelete())
+								.referencing(referredTable, fk.getReferredColumns());
 					});
 				}
 				else {
@@ -513,6 +518,9 @@ public class GreedyMigrationPlanner implements MigrationPlanner {
 
 						Table newReferredTable = catalog.getTable(newReferredTableId);
 						newTable.addForeignKey(foreignKey.getReferencingColumns())
+								.named(foreignKey.getForeignKeyName())
+								.onUpdate(foreignKey.getOnUpdate())
+								.onDelete(foreignKey.getOnDelete())
 								.referencing(newReferredTable, foreignKey.getReferredColumns());
 					}
 				}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddForeignKeyMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddForeignKeyMigrator.java
@@ -24,6 +24,9 @@ class AddForeignKeyMigrator implements SchemaOperationMigrator<AddForeignKey> {
 		Table referencedTable = catalog.getTable(referencedTableId);
 
 		table.addForeignKey(operation.getReferringColumnNames())
+				.named(operation.getName())
+				.onDelete(operation.getOnDelete())
+				.onUpdate(operation.getOnUpdate())
 				.referencing(referencedTable, operation.getReferencedColumnNames());
 	}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CopyTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CopyTableMigrator.java
@@ -34,6 +34,9 @@ class CopyTableMigrator implements SchemaOperationMigrator<CopyTable> {
 
 			Table referredTable = catalog.getTable(referredTableId);
 			copy.addForeignKey(foreignKey.getReferencingColumns().toArray(new String[0]))
+					.named(foreignKey.getForeignKeyName())
+					.onUpdate(foreignKey.getOnUpdate())
+					.onDelete(foreignKey.getOnDelete())
 					.referencing(referredTable, foreignKey.getReferredColumns().toArray(new String[0]));
 		}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropForeignKeyMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropForeignKeyMigrator.java
@@ -1,9 +1,5 @@
 package io.quantumdb.core.migration.operations;
 
-import java.util.List;
-
-import com.google.common.base.Joiner;
-import com.google.common.collect.Sets;
 import io.quantumdb.core.migration.utils.DataMappings;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.ForeignKey;
@@ -25,13 +21,10 @@ class DropForeignKeyMigrator implements SchemaOperationMigrator<DropForeignKey> 
 		Table table = catalog.getTable(tableId);
 
 		ForeignKey matchedForeignKey = table.getForeignKeys().stream()
-				.filter(foreignKey -> {
-					List<String> referencingColumns = foreignKey.getReferencingColumns();
-					return referencingColumns.containsAll(Sets.newHashSet(operation.getReferringColumnNames()));
-				})
+				.filter(foreignKey -> foreignKey.getForeignKeyName().equals(operation.getForeignKeyName()))
 				.findFirst()
 				.orElseThrow(() -> new IllegalStateException("No foreign key exists in table: " + tableName
-						+ " for the column(s): " + Joiner.on(", ").join(operation.getReferringColumnNames())));
+						+ " with name: " + operation.getForeignKeyName()));
 
 		matchedForeignKey.drop();
 	}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
@@ -65,7 +65,11 @@ class TransitiveTableMirrorer {
 				String[] referencingColumnNames = foreignKey.getReferencingColumns().toArray(new String[0]);
 				String[] referredColumnNames = foreignKey.getReferredColumns().toArray(new String[0]);
 
-				newTable.addForeignKey(referencingColumnNames).referencing(newReferredTable, referredColumnNames);
+				newTable.addForeignKey(referencingColumnNames)
+						.named(foreignKey.getForeignKeyName())
+						.onUpdate(foreignKey.getOnUpdate())
+						.onDelete(foreignKey.getOnDelete())
+						.referencing(newReferredTable, referredColumnNames);
 			}
 		}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Catalog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Catalog.java
@@ -120,6 +120,9 @@ public class Catalog implements Copyable<Catalog> {
 			Table source = schema.getTable(foreignKey.getReferencingTableName());
 			Table target = schema.getTable(foreignKey.getReferredTableName());
 			source.addForeignKey(foreignKey.getReferencingColumns())
+					.named(foreignKey.getForeignKeyName())
+					.onDelete(foreignKey.getOnDelete())
+					.onUpdate(foreignKey.getOnUpdate())
 					.referencing(target, foreignKey.getReferredColumns());
 		}
 		for (Sequence sequence : sequences) {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ForeignKey.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ForeignKey.java
@@ -1,6 +1,7 @@
 package io.quantumdb.core.schema.definitions;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -15,14 +16,24 @@ import lombok.Data;
 @Data
 public class ForeignKey {
 
+	public static enum Action {
+		CASCADE, RESTRICT, NO_ACTION, SET_DEFAULT, SET_NULL
+	}
+
+	private final String foreignKeyName;
 	private final Table referencingTable;
 	private final Table referredTable;
 	private final ImmutableList<String> referencingColumns;
 	private final ImmutableList<String> referredColumns;
+	private Action onUpdate;
+	private Action onDelete;
 
-	ForeignKey(Table referencingTable, List<String> referencingColumns,
-			Table referredTable, List<String> referredColumns) {
+	ForeignKey(String foreignKeyName, Table referencingTable, List<String> referencingColumns, Table referredTable,
+			List<String> referredColumns, Action onUpdate, Action onDelete) {
 
+		checkArgument(!isNullOrEmpty(foreignKeyName), "You must specify a 'foreignKeyName'.");
+		checkArgument(onUpdate != null, "You must specify an 'onUpdate' action.");
+		checkArgument(onDelete != null, "You must specify an 'onDelete' action.");
 		checkArgument(referredColumns.size() == referencingColumns.size(),
 				"You must refer to as many columns as you are referring from.");
 
@@ -35,10 +46,13 @@ public class ForeignKey {
 					"The column: " + referredColumn + " is not present in table: " +referredTable.getName());
 		}
 
+		this.foreignKeyName = foreignKeyName;
 		this.referencingTable = referencingTable;
 		this.referredTable = referredTable;
 		this.referencingColumns = ImmutableList.copyOf(referencingColumns);
 		this.referredColumns = ImmutableList.copyOf(referredColumns);
+		this.onUpdate = onUpdate;
+		this.onDelete = onDelete;
 	}
 
 	public String getReferredTableName() {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/PrettyPrinter.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/PrettyPrinter.java
@@ -60,9 +60,17 @@ class PrettyPrinter {
 			.registerTypeAdapter(ForeignKey.class, new JsonSerializer<ForeignKey>() {
 				@Override
 				public JsonElement serialize(ForeignKey src, Type typeOfSrc, JsonSerializationContext context) {
+					JsonObject mapping = new JsonObject();
+					src.getColumnMapping().entrySet()
+							.forEach(entry -> mapping.addProperty(entry.getKey(), entry.getValue()));
+
 					JsonObject model = new JsonObject();
-					model.addProperty("referringFrom", src.getReferencingTableName() + ": " + Joiner.on(", ").join(src.getReferencingColumns()));
-					model.addProperty("referringTo", src.getReferredTableName() + ": " + Joiner.on(", ").join(src.getReferredColumns()));
+					model.addProperty("name", src.getForeignKeyName());
+					model.addProperty("from", src.getReferencingTableName());
+					model.addProperty("to", src.getReferredTableName());
+					model.add("mapping", mapping);
+					model.addProperty("onUpdate", src.getOnUpdate().name());
+					model.addProperty("onDelete", src.getOnDelete().name());
 					return model;
 				}
 			})

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/AddForeignKey.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/AddForeignKey.java
@@ -3,6 +3,8 @@ package io.quantumdb.core.schema.operations;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Strings;
+import io.quantumdb.core.schema.definitions.ForeignKey.Action;
+import io.quantumdb.core.utils.RandomHasher;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
@@ -14,6 +16,10 @@ public class AddForeignKey implements SchemaOperation {
 	private final String referringTableName;
 	private final String[] referringColumnNames;
 
+	private String name;
+	private Action onDelete;
+	private Action onUpdate;
+
 	private String referencedTableName;
 	private String[] referencedColumnNames;
 
@@ -21,8 +27,26 @@ public class AddForeignKey implements SchemaOperation {
 		checkArgument(!Strings.isNullOrEmpty(table), "You must specify a 'table'.");
 		checkArgument(columns != null && columns.length > 0, "You must specify at least one 'column'.");
 
+		this.name = "fk_" + RandomHasher.generateHash();
+		this.onDelete = Action.NO_ACTION;
+		this.onUpdate= Action.NO_ACTION;
 		this.referringTableName = table;
 		this.referringColumnNames = columns;
+	}
+
+	public AddForeignKey named(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public AddForeignKey onDelete(Action action) {
+		this.onDelete = action;
+		return this;
+	}
+
+	public AddForeignKey onUpdate(Action action) {
+		this.onUpdate = action;
+		return this;
 	}
 
 	public AddForeignKey referencing(String table, String... columns) {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/DropForeignKey.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/DropForeignKey.java
@@ -11,14 +11,14 @@ import lombok.experimental.Accessors;
 public class DropForeignKey implements SchemaOperation {
 
 	private final String tableName;
-	private final String[] referringColumnNames;
+	private final String foreignKeyName;
 
-	DropForeignKey(String tableName, String... columns) {
+	DropForeignKey(String tableName, String foreignKeyName) {
 		checkArgument(!Strings.isNullOrEmpty(tableName), "You must specify a 'table'.");
-		checkArgument(columns != null && columns.length > 0, "You must specify at least one 'column'.");
+		checkArgument(!Strings.isNullOrEmpty(foreignKeyName), "You must specify a 'foreignKeyName'.");
 
 		this.tableName = tableName;
-		this.referringColumnNames = columns;
+		this.foreignKeyName = foreignKeyName;
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/SchemaOperations.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/SchemaOperations.java
@@ -61,8 +61,8 @@ public class SchemaOperations {
 		return new AddForeignKey(table, columns);
 	}
 
-	public static DropForeignKey dropForeignKey(String tableName, String... columns) {
-		return new DropForeignKey(tableName, columns);
+	public static DropForeignKey dropForeignKey(String tableName, String foreignKeyName) {
+		return new DropForeignKey(tableName, foreignKeyName);
 	}
 
 }

--- a/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/videostores/DropForeignKeyFromCustomersTable.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/videostores/DropForeignKeyFromCustomersTable.java
@@ -42,7 +42,7 @@ public class DropForeignKeyFromCustomersTable {
 		origin = setup.getChangelog().getLastAdded();
 
 		setup.getChangelog().addChangeSet("Michael de Jong",
-				SchemaOperations.dropForeignKey("customers", "store_id"));
+				SchemaOperations.dropForeignKey("customers", "customer_registered_at_store"));
 
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());

--- a/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/videostores/PostgresqlBaseScenario.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/videostores/PostgresqlBaseScenario.java
@@ -104,7 +104,9 @@ public class PostgresqlBaseScenario extends PostgresqlDatabase {
 		staff.addForeignKey("store_id").referencing(stores, "id");
 
 		customers.addForeignKey("referred_by").referencing(customers, "id");
-		customers.addForeignKey("store_id").referencing(stores, "id");
+		customers.addForeignKey("store_id")
+				.named("customer_registered_at_store")
+				.referencing(stores, "id");
 
 		inventory.addForeignKey("store_id").referencing(stores, "id");
 		inventory.addForeignKey("film_id").referencing(films, "id");

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropForeignKeyMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropForeignKeyMigratorTest.java
@@ -38,7 +38,9 @@ public class DropForeignKeyMigratorTest {
 
 		Table posts = catalog.getTable("posts");
 		Table users = catalog.getTable("users");
-		posts.addForeignKey("author").referencing(users, "id");
+		posts.addForeignKey("author")
+				.named("post_author")
+				.referencing(users, "id");
 
 		this.changelog = new Changelog();
 		this.tableMapping = TableMapping.bootstrap(changelog.getRoot(), catalog);
@@ -49,7 +51,7 @@ public class DropForeignKeyMigratorTest {
 
 	@Test
 	public void testExpandForDroppingForeignKey() {
-		DropForeignKey operation = dropForeignKey("posts", "author");
+		DropForeignKey operation = dropForeignKey("posts", "post_author");
 		changelog.addChangeSet("Michael de Jong", "Drop author foreign key from posts table.", operation);
 		migrator.migrate(catalog, tableMapping, dataMappings, changelog.getLastAdded(), operation);
 


### PR DESCRIPTION
Instead of specifying columns in foreign key related schema operations, the name of the foreign key can now be used.
