### PR TITLE
Support intermediate stages when applying data changes

### DIFF
--- a/modules/quantumdb_postgresql/manifests/init.pp
+++ b/modules/quantumdb_postgresql/manifests/init.pp
@@ -21,7 +21,7 @@ class quantumdb_postgresql($version = "9.6"){
 		encoding            => 'UTF-8',
 		locale              => 'en_US.UTF-8',
 		manage_package_repo => true,
-		version             => $version,
+		version             => $version
 	}
 	->
 	class { 'postgresql::server':

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/Cli.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/Cli.java
@@ -1,0 +1,23 @@
+package io.quantumdb.cli;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.sql.SQLException;
+
+public class Cli {
+
+	public static void main(String[] args) throws IOException, SQLException {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+
+		String line;
+		while ((line = reader.readLine()) != null) {
+			if (line.equals("\\q")) {
+				return;
+			}
+
+			Main.main(line.split(" "));
+		}
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Fork.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Fork.java
@@ -53,6 +53,10 @@ public class Fork extends Command {
 	private Version getOriginVersion(List<String> arguments, State state, Changelog changelog) throws CliException {
 		if (arguments.isEmpty()) {
 			List<Version> versions = Lists.newArrayList(state.getRefLog().getVersions());
+			if (versions.isEmpty()) {
+				versions.add(changelog.getRoot());
+			}
+
 			if (versions.size() == 1) {
 				return versions.get(0);
 			}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
@@ -7,6 +7,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.quantumdb.cli.utils.CliWriter;
 import io.quantumdb.cli.utils.CliWriter.Context;
@@ -25,7 +26,8 @@ public class Query extends Command {
 		try {
 			Config config = Config.load();
 			String versionId = arguments.remove(0);
-			String query = arguments.remove(0);
+			String query = arguments.stream()
+					.collect(Collectors.joining(" "));
 
 			Class.forName("io.quantumdb.driver.Driver");
 			String url = createUrl(config.getUrl(), config.getCatalog(), versionId);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/postgresql/CatalogLoader.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/postgresql/CatalogLoader.java
@@ -114,7 +114,7 @@ class CatalogLoader {
 				if (!"yes".equalsIgnoreCase(resultSet.getString("is_nullable"))) {
 					hints.add(Column.Hint.NOT_NULL);
 				}
-				if (primaryKeys.contains(columnName) || (primaryKeys.isEmpty() && columns.isEmpty())) { // TODO: <--- HACK!!
+				if (primaryKeys.contains(columnName) || (primaryKeys.isEmpty() && columns.isEmpty())) {
 					hints.add(Column.Hint.IDENTITY);
 				}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/postgresql/TableDataMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/postgresql/TableDataMigrator.java
@@ -154,7 +154,6 @@ class TableDataMigrator {
 			Object right = limit.get(key);
 
 			if (left == null || right == null) {
-				// TODO: Should account for NULLs in identity columns?
 				throw new IllegalStateException("NULL values in identity columns are currently not supported.");
 			}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/RenameTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/RenameTableMigrator.java
@@ -15,7 +15,8 @@ public class RenameTableMigrator implements SchemaOperationMigrator<RenameTable>
 	public void migrate(Catalog catalog, RefLog refLog, Version version, RenameTable operation) {
 		refLog.fork(version);
 		TableRef tableRef = refLog.getTableRef(version, operation.getTableName());
-		tableRef.rename(operation.getNewTableName());
+		TableRef ghost = tableRef.ghost(tableRef.getTableId(), version);
+		ghost.rename(operation.getNewTableName());
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Catalog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Catalog.java
@@ -85,7 +85,10 @@ public class Catalog implements Copyable<Catalog> {
 		sequences.remove(sequence);
 		sequence.setParent(null);
 
-		// TODO: Remove reference from all columns in catalog.
+		tables.stream()
+				.flatMap(table -> table.getColumns().stream())
+				.filter(column -> sequence.equals(column.getSequence()))
+				.forEach(Column::dropDefaultValue);
 
 		return sequence;
 	}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Column.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Column.java
@@ -77,6 +77,7 @@ public class Column implements Copyable<Column> {
 
 	public void dropDefaultValue() {
 		this.defaultValue = null;
+		this.sequence = null;
 		this.hints.remove(Hint.AUTO_INCREMENT);
 	}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Backend.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Backend.java
@@ -166,7 +166,7 @@ public class Backend {
 										.filter(mapping -> mapping.getTarget().equals(column))
 										.map(TableColumnMapping::getSource)
 										.map(columnCache::get)
-										.filter(ref -> ref != null) // TODO: Really needed?
+										.filter(ref -> ref != null)
 										.collect(Collectors.toList());
 
 								return new ColumnRef(column.getColumn(), basedOn);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Backend.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Backend.java
@@ -3,6 +3,7 @@ package io.quantumdb.core.versioning;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
@@ -14,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -24,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
+import com.google.common.collect.Table.Cell;
 import com.google.common.primitives.Ints;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -39,19 +42,20 @@ import io.quantumdb.core.versioning.RefLog.ColumnRef;
 import io.quantumdb.core.versioning.RefLog.SyncRef;
 import io.quantumdb.core.versioning.RefLog.TableRef;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class Backend {
 
 	@Data
 	private static class TableId {
 		private final String tableId;
-		private final String tableName;
 	}
 
 	@Data
 	private static class TableColumn {
 		private final long id;
-		private final TableId table;
+		private final TableId tableId;
 		private final String column;
 	}
 
@@ -131,12 +135,12 @@ public class Backend {
 	public State load(Connection connection, Catalog catalog) throws SQLException {
 		Changelog changelog = loadChangelog(connection);
 		Map<String, TableId> tableIds = listTableIds(connection);
-		Multimap<Version, TableId> tableVersions = listTableVersions(connection, tableIds, changelog);
+		Table<TableId, Version, String> tableVersions = listTableVersions(connection, tableIds, changelog);
 		List<TableColumn> tableColumns = listTableColumns(connection, tableIds);
 		List<TableColumnMapping> columnMappings = listTableColumnMappings(connection, tableColumns);
 
 		Multimap<TableId, TableColumn> columnsPerTable = LinkedHashMultimap.create();
-		tableColumns.forEach(column -> columnsPerTable.put(column.getTable(), column));
+		tableColumns.forEach(column -> columnsPerTable.put(column.getTableId(), column));
 
 		Map<TableColumn, ColumnRef> columnCache = Maps.newLinkedHashMap();
 
@@ -146,9 +150,9 @@ public class Backend {
 
 		while (!toDo.isEmpty()) {
 			Version version = toDo.remove(0);
-			for (TableId table : tableVersions.get(version)) {
+			for (Entry<TableId, String> entry : tableVersions.column(version).entrySet()) {
 				TableRef tableRef = refLog.getTableRefs(version).stream()
-						.filter(ref -> ref.getName().equals(table.getTableName()))
+						.filter(ref -> ref.getName().equals(entry.getValue()) && ref.getTableId().equals(entry.getKey().getTableId()))
 						.findFirst()
 						.orElse(null);
 
@@ -156,7 +160,7 @@ public class Backend {
 					tableRef.markAsPresent(version);
 				}
 				else {
-					Map<TableColumn, ColumnRef> columnRefs = columnsPerTable.get(table).stream()
+					Map<TableColumn, ColumnRef> columnRefs = columnsPerTable.get(entry.getKey()).stream()
 							.collect(Collectors.toMap(Function.identity(), column -> {
 								List<ColumnRef> basedOn = columnMappings.stream()
 										.filter(mapping -> mapping.getTarget().equals(column))
@@ -169,7 +173,7 @@ public class Backend {
 							}, (l, r) -> l, LinkedHashMap::new));
 
 					columnCache.putAll(columnRefs);
-					refLog.addTable(table.getTableName(), table.getTableId(), version, columnRefs.values());
+					refLog.addTable(entry.getValue(), entry.getKey().getTableId(), version, columnRefs.values());
 				}
 			}
 
@@ -192,7 +196,7 @@ public class Backend {
 		Collection<RawTableColumn> columns = persistTableColumns(connection, refLog);
 		Map<Long, RawColumnMapping> columnMapping = persistColumnMappings(connection, refLog, columns);
 		Map<Long, SyncRef> syncRefs = persistTableSynchronizers(connection, refLog);
-		persistSynchronizerColumns(connection, refLog, syncRefs, columnMapping);
+		persistSynchronizerColumns(connection, syncRefs, columnMapping);
 	}
 
 	private void persistChangelog(Connection connection, Changelog changelog) throws SQLException {
@@ -247,13 +251,16 @@ public class Backend {
 							update.setString(3, version.getParent().getId());
 						}
 						update.setString(4, versionId);
+
 						update.execute();
+						log.debug("Updated entry for changelog id: {}", versionId);
 					}
 				}
 				else {
 					try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 						delete.setString(1, versionId);
 						delete.execute();
+						log.debug("Deleted entry for changelog id: {}", versionId);
 					}
 				}
 			}
@@ -277,13 +284,14 @@ public class Backend {
 						insert.setString(3, null);
 					}
 
-					if (version.getParent() == null) {
-						insert.setString(4, null);
+					String versionId = null;
+					if (version.getParent() != null) {
+						versionId = version.getParent().getId();
 					}
-					else {
-						insert.setString(4, version.getParent().getId());
-					}
+
+					insert.setString(4, versionId);
 					insert.execute();
+					log.debug("Inserted new entry for changelog id: {}", versionId);
 				}
 			}
 
@@ -321,12 +329,14 @@ public class Backend {
 						update.setTimestamp(3, new Timestamp(changeSet.getCreated().getTime()));
 						update.setString(4, versionId);
 						update.execute();
+						log.debug("Updated entry for changeset id: {}", versionId);
 					}
 				}
 				else {
 					try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 						delete.setString(1, versionId);
 						delete.execute();
+						log.debug("Deleted entry for changeset id: {}", versionId);
 					}
 				}
 			}
@@ -334,7 +344,8 @@ public class Backend {
 			if (!mapping.isEmpty()) {
 				PreparedStatement insert = connection.prepareStatement(insertQuery);
 				for (Entry<String, ChangeSet> entry : mapping.entrySet()) {
-					insert.setString(1, entry.getKey());
+					String versionId = entry.getKey();
+					insert.setString(1, versionId);
 
 					ChangeSet changeSet = entry.getValue();
 					if (changeSet != null) {
@@ -348,6 +359,7 @@ public class Backend {
 						insert.setTimestamp(4, Timestamp.from(Instant.now()));
 					}
 					insert.execute();
+					log.debug("Inserted new entry for changeset id: {}", versionId);
 				}
 			}
 
@@ -356,42 +368,48 @@ public class Backend {
 	}
 
 	private void persistTables(Connection connection, RefLog refLog) throws SQLException {
-		Map<String, String> tableNameMapping = refLog.getTableRefs().stream()
-				.collect(Collectors.toMap(TableRef::getTableId, TableRef::getName));
+		Set<String> tableIds = refLog.getTableRefs().stream()
+				.map(TableRef::getTableId)
+				.collect(Collectors.toSet());
 
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_tables ORDER BY table_name ASC;";
+			String query = "SELECT * FROM quantumdb_tables ORDER BY table_id ASC;";
 			String deleteQuery = "DELETE FROM quantumdb_tables WHERE table_id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_tables (table_id, table_name) VALUES (?, ?);";
-			String updateQuery = "UPDATE quantumdb_tables SET table_name = ? WHERE table_id = ?;";
+			String insertQuery = "INSERT INTO quantumdb_tables (table_id) VALUES (?);";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
 				String tableId = resultSet.getString("table_id");
-				if (tableNameMapping.containsKey(tableId)) {
-					String tableName = tableNameMapping.remove(tableId);
-					if (!resultSet.getString("table_name").equals(tableName)) {
-						try (PreparedStatement update = connection.prepareStatement(updateQuery)) {
-							update.setString(1, tableName);
-							update.setString(2, tableId);
-							update.execute();
-						}
+				if (!tableIds.remove(tableId)) {
+					try (Statement stmt = connection.createStatement()) {
+						ResultSet r = stmt.executeQuery("SELECT * FROM quantumdb_column_mappings");
+						printResults(r);
 					}
-				}
-				else {
+
+					try (Statement stmt = connection.createStatement()) {
+						ResultSet r = stmt.executeQuery("SELECT * FROM quantumdb_table_columns");
+						printResults(r);
+					}
+
+					try (Statement stmt = connection.createStatement()) {
+						ResultSet r = stmt.executeQuery("SELECT * FROM quantumdb_tables");
+						printResults(r);
+					}
+
 					try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 						delete.setString(1, tableId);
 						delete.execute();
+						log.debug("Deleted entry for table id: {}", tableId);
 					}
 				}
 			}
 
-			if (!tableNameMapping.isEmpty()) {
+			if (!tableIds.isEmpty()) {
 				PreparedStatement insert = connection.prepareStatement(insertQuery);
-				for (Entry<String, String> entry : tableNameMapping.entrySet()) {
-					insert.setString(1, entry.getKey());
-					insert.setString(2, entry.getValue());
+				for (String tableId : tableIds) {
+					insert.setString(1, tableId);
 					insert.execute();
+					log.debug("Inserted new entry for table id: {}", tableId);
 				}
 			}
 
@@ -399,34 +417,58 @@ public class Backend {
 		}
 	}
 
+	private void printResults(ResultSet r) throws SQLException {
+		ResultSetMetaData metaData = r.getMetaData();
+		while (r.next()) {
+			StringBuilder builder = new StringBuilder();
+			builder.append("[" + metaData.getTableName(1) + "] ");
+			for (int i = 0; i < metaData.getColumnCount(); i++) {
+				builder.append(metaData.getColumnName(i + 1));
+				builder.append("=");
+				builder.append(r.getObject(i + 1));
+
+				if (i < metaData.getColumnCount() - 1) {
+					builder.append(", ");
+				}
+			}
+			System.out.println(builder.toString());
+		}
+	}
+
 	private void persistTableVersions(Connection connection, RefLog refLog) throws SQLException {
-		Multimap<String, String> versionMapping = HashMultimap.create();
-		refLog.getTableRefs()
-				.forEach(tableRef -> versionMapping.putAll(tableRef.getTableId(), tableRef.getVersions().stream()
-						.map(Version::getId)
-						.collect(Collectors.toSet())));
+		Table<String, String, String> mapping = HashBasedTable.create();
+		refLog.getTableRefs().forEach(tableRef -> {
+			String tableId = tableRef.getTableId();
+			String tableName = tableRef.getName();
+			Set<String> versionIds = tableRef.getVersions().stream()
+					.map(Version::getId)
+					.collect(Collectors.toSet());
+
+			versionIds.forEach(versionId -> mapping.put(tableId, versionId, tableName));
+		});
 
 		try (Statement statement = connection.createStatement()) {
 			String query = "SELECT * FROM quantumdb_table_versions ORDER BY table_id ASC;";
 			String deleteQuery = "DELETE FROM quantumdb_table_versions WHERE table_id = ? AND version_id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_table_versions (table_id, version_id) VALUES (?, ?);";
+			String insertQuery = "INSERT INTO quantumdb_table_versions (table_id, version_id, table_name) VALUES (?, ?, ?);";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
 				String tableId = resultSet.getString("table_id");
 				String versionId = resultSet.getString("version_id");
 
-				if (versionMapping.containsKey(tableId)) {
-					Collection<String> versions = versionMapping.get(tableId);
-					if (!versions.contains(versionId)) {
+				if (mapping.containsRow(tableId)) {
+					Map<String, String> internalMapping = mapping.row(tableId);
+					if (!internalMapping.containsKey(versionId)) {
 						try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 							delete.setString(1, tableId);
 							delete.setString(2, versionId);
 							delete.execute();
+							log.debug("Deleted entry for table_versions id: {} / {}", tableId, versionId);
 						}
 					}
 					else {
-						versionMapping.remove(tableId, versionId);
+						mapping.remove(tableId, versionId);
 					}
 				}
 				else {
@@ -434,16 +476,23 @@ public class Backend {
 						delete.setString(1, tableId);
 						delete.setString(2, versionId);
 						delete.execute();
+						log.debug("Deleted entry for table_versions id: {} / {}", tableId, versionId);
 					}
 				}
 			}
 
-			if (!versionMapping.isEmpty()) {
+			if (!mapping.isEmpty()) {
 				PreparedStatement insert = connection.prepareStatement(insertQuery);
-				for (Entry<String, String> entry : versionMapping.entries()) {
-					insert.setString(1, entry.getKey());
-					insert.setString(2, entry.getValue());
+				for (Cell<String, String, String> entry : mapping.cellSet()) {
+					String tableId = entry.getRowKey();
+					String versionId = entry.getColumnKey();
+
+					insert.setString(1, tableId);
+					insert.setString(2, versionId);
+					insert.setString(3, entry.getValue());
 					insert.execute();
+
+					log.debug("Inserted new entry for table_versions id: {} / {}", tableId, versionId);
 				}
 			}
 
@@ -473,6 +522,7 @@ public class Backend {
 						try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 							delete.setLong(1, id);
 							delete.execute();
+							log.debug("Deleted entry for table_columns id: {} - {} / {}", id, tableId, columnName);
 						}
 					}
 					else {
@@ -484,6 +534,7 @@ public class Backend {
 					try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 						delete.setLong(1, id);
 						delete.execute();
+						log.debug("Deleted entry for table_columns id: {}", id);
 					}
 				}
 			}
@@ -491,13 +542,17 @@ public class Backend {
 			if (!columnMapping.isEmpty()) {
 				try (PreparedStatement insert = connection.prepareStatement(insertQuery)) {
 					for (Entry<String, String> entry : columnMapping.entries()) {
-						insert.setString(1, entry.getKey());
-						insert.setString(2, entry.getValue());
+						String tableId = entry.getKey();
+						String columnName = entry.getValue();
+
+						insert.setString(1, tableId);
+						insert.setString(2, columnName);
 						ResultSet generatedKeys = insert.executeQuery();
 						generatedKeys.next();
 
 						long id = generatedKeys.getLong("id");
-						columns.add(new RawTableColumn(id, entry.getKey(), entry.getValue()));
+						columns.add(new RawTableColumn(id, tableId, columnName));
+						log.debug("Inserted new entry for table_columns id: {} - {} / {}", id, tableId, columnName);
 					}
 				}
 			}
@@ -527,6 +582,7 @@ public class Backend {
 					RawColumn source = new RawColumn(sourceTableId, sourceColumnName);
 
 					columnMapping.put(source, target);
+					columnMapping.put(target, source);
 				}
 			}
 		}
@@ -554,6 +610,7 @@ public class Backend {
 					try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 						delete.setLong(1, id);
 						delete.execute();
+						log.debug("Deleted entry for column_mappings id: {}", id);
 					}
 				}
 			}
@@ -571,6 +628,7 @@ public class Backend {
 
 						long id = generatedKeys.getLong("id");
 						results.put(id, new RawColumnMapping(id, entry.getKey(), entry.getValue()));
+						log.debug("Inserted new entry for column_mappings id: {} - {} / {}", id, sourceId, targetId);
 					}
 				}
 			}
@@ -611,6 +669,7 @@ public class Backend {
 						update.setString(2, syncRef.getFunctionName());
 						update.setLong(3, id);
 						update.execute();
+						log.debug("Updated entry for synchronizers id: {} - {} -> {}", id, sourceTableId, targetTableId);
 					}
 
 					mapping.put(id, syncRef);
@@ -619,6 +678,7 @@ public class Backend {
 					try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 						delete.setLong(1, id);
 						delete.execute();
+						log.debug("Deleted entry for synchronizers id: {}", id);
 					}
 				}
 			}
@@ -626,8 +686,11 @@ public class Backend {
 			if (!syncMapping.isEmpty()) {
 				PreparedStatement insert = connection.prepareStatement(insertQuery);
 				for (SyncRef syncRef : syncMapping.values()) {
-					insert.setString(1, syncRef.getSource().getTableId());
-					insert.setString(2, syncRef.getTarget().getTableId());
+					String sourceTableId = syncRef.getSource().getTableId();
+					String targetTableId = syncRef.getTarget().getTableId();
+
+					insert.setString(1, sourceTableId);
+					insert.setString(2, targetTableId);
 					insert.setString(3, syncRef.getName());
 					insert.setString(4, syncRef.getFunctionName());
 					ResultSet generatedKeys = insert.executeQuery();
@@ -635,6 +698,7 @@ public class Backend {
 					generatedKeys.next();
 					long id = generatedKeys.getLong("id");
 					mapping.put(id, syncRef);
+					log.debug("Inserted new entry for synchronizers id: {} - {} -> {}", id, sourceTableId, targetTableId);
 				}
 			}
 
@@ -643,7 +707,7 @@ public class Backend {
 		return mapping;
 	}
 
-	private void persistSynchronizerColumns(Connection connection, RefLog refLog, Map<Long, SyncRef> syncRefs,
+	private void persistSynchronizerColumns(Connection connection, Map<Long, SyncRef> syncRefs,
 			Map<Long, RawColumnMapping> columnMapping) throws SQLException {
 
 		Table<String, String, Long> syncIndex = HashBasedTable.create();
@@ -653,8 +717,10 @@ public class Backend {
 		columnMapping.forEach((id, mapping) -> {
 			String sourceTableId = mapping.getSource().getTable();
 			String targetTableId = mapping.getTarget().getTable();
-			long syncId = syncIndex.get(sourceTableId, targetTableId);
-			idMapping.put(syncId, mapping.getId());
+			Long syncId = syncIndex.get(sourceTableId, targetTableId);
+			if (syncId != null) {
+				idMapping.put(syncId, mapping.getId());
+			}
 		});
 
 		try (Statement statement = connection.createStatement()) {
@@ -675,6 +741,7 @@ public class Backend {
 						delete.setLong(1, synchronizerId);
 						delete.setLong(2, columnMappingId);
 						delete.execute();
+						log.debug("Deleted entry for synchronizer_columns id: {}, mapping: {}", synchronizerId, columnMappingId);
 					}
 				}
 			}
@@ -682,9 +749,12 @@ public class Backend {
 			if (!idMapping.isEmpty()) {
 				PreparedStatement insert = connection.prepareStatement(insertQuery);
 				for (Entry<Long, Long> idEntry : idMapping.entries()) {
-					insert.setLong(1, idEntry.getKey());
-					insert.setLong(2, idEntry.getValue());
+					Long synchronizerId = idEntry.getKey();
+					Long columnMappingId = idEntry.getValue();
+					insert.setLong(1, synchronizerId);
+					insert.setLong(2, columnMappingId);
 					insert.execute();
+					log.debug("Inserted new entry for synchronizer_columns id: {}, mapping: {}", synchronizerId, columnMappingId);
 				}
 			}
 
@@ -815,28 +885,28 @@ public class Backend {
 	}
 
 	private Map<String, TableId> listTableIds(Connection connection) throws SQLException {
-		Map<String, TableId> mapping = Maps.newLinkedHashMap();
+		Map<String, TableId> tableIds = Maps.newHashMap();
 		try (Statement statement = connection.createStatement()) {
-			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb_tables ORDER BY table_name ASC;");
+			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb_tables ORDER BY table_id ASC;");
 			while (resultSet.next()) {
 				String tableId = resultSet.getString("table_id");
-				String tableName = resultSet.getString("table_name");
-				mapping.put(tableId, new TableId(tableId, tableName));
+				tableIds.put(tableId, new TableId(tableId));
 			}
 		}
-		return mapping;
+		return tableIds;
 	}
 
-	private Multimap<Version, TableId> listTableVersions(Connection connection, Map<String, TableId> tableIds, Changelog changelog) throws SQLException {
-		Multimap<Version, TableId> mapping = LinkedHashMultimap.create();
+	private Table<TableId, Version, String> listTableVersions(Connection connection, Map<String, TableId> tableIds, Changelog changelog) throws SQLException {
+		Table<TableId, Version, String> mapping = HashBasedTable.create();
 		try (Statement statement = connection.createStatement()) {
 			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb_table_versions ORDER BY table_id ASC;");
 			while (resultSet.next()) {
 				String tableId = resultSet.getString("table_id");
+				String tableName = resultSet.getString("table_name");
 				String versionId = resultSet.getString("version_id");
-				TableId table = tableIds.get(tableId);
 				Version version = changelog.getVersion(versionId);
-				mapping.put(version, table);
+				TableId tableIdRef = tableIds.get(tableId);
+				mapping.put(tableIdRef, version, tableName);
 			}
 		}
 		return mapping;
@@ -850,8 +920,8 @@ public class Backend {
 				long id = resultSet.getLong("id");
 				String tableId = resultSet.getString("table_id");
 				String column = resultSet.getString("column_name");
-				TableId table = tableIds.get(tableId);
-				results.add(new TableColumn(id, table, column));
+				TableId tableIdRef = tableIds.get(tableId);
+				results.add(new TableColumn(id, tableIdRef, column));
 			}
 		}
 		return results;
@@ -880,7 +950,7 @@ public class Backend {
 		Map<Long, TableColumnMapping> columnMapping = columnMappings.stream()
 				.collect(Collectors.toMap(TableColumnMapping::getId, Function.identity()));
 
-		Multimap<Long, Long> syncColumMappings = HashMultimap.create();
+		Multimap<Long, Long> syncColumnMappings = HashMultimap.create();
 		try (Statement statement = connection.createStatement()) {
 			String query = "SELECT * FROM quantumdb_synchronizer_columns;";
 
@@ -888,7 +958,7 @@ public class Backend {
 			while (resultSet.next()) {
 				long synchronizerId = resultSet.getLong("synchronizer_id");
 				long columnMappingId = resultSet.getLong("column_mapping_id");
-				syncColumMappings.put(synchronizerId, columnMappingId);
+				syncColumnMappings.put(synchronizerId, columnMappingId);
 			}
 		}
 
@@ -903,25 +973,25 @@ public class Backend {
 				String triggerName = resultSet.getString("trigger_name");
 				String functionName = resultSet.getString("function_name");
 
-				Map<ColumnRef, ColumnRef> mappingsForSynchronizer = syncColumMappings.get(id).stream()
+				Map<ColumnRef, ColumnRef> mappingsForSynchronizer = syncColumnMappings.get(id).stream()
 						.map(columnMapping::get)
 						.collect(Collectors.toMap(entry -> {
 							TableColumn source = entry.getSource();
-							if (!source.getTable().getTableId().equals(sourceTableId)) {
+							if (!source.getTableId().getTableId().equals(sourceTableId)) {
 								throw new IllegalStateException("The column mapping of synchronizer: " + id
-										+ " originates to a table: " + source.getTable().getTableId()
+										+ " originates to a table: " + source.getTableId().getTableId()
 										+ " other than the source table: " + sourceTableId);
 							}
-							TableRef ref = refLog.getTableRefById(source.getTable().getTableId());
+							TableRef ref = refLog.getTableRefById(source.getTableId().getTableId());
 							return ref.getColumns().get(source.getColumn());
 						}, entry -> {
 							TableColumn target = entry.getTarget();
-							if (!target.getTable().getTableId().equals(targetTableId)) {
+							if (!target.getTableId().getTableId().equals(targetTableId)) {
 								throw new IllegalStateException("The column mapping of synchronizer: " + id
-										+ " targets into a table: " + target.getTable().getTableId()
+										+ " targets into a table: " + target.getTableId().getTableId()
 										+ " other than the target table: " + targetTableId);
 							}
-							TableRef ref = refLog.getTableRefById(target.getTable().getTableId());
+							TableRef ref = refLog.getTableRefById(target.getTableId().getTableId());
 							return ref.getColumns().get(target.getColumn());
 						}));
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
@@ -14,6 +14,7 @@ import io.quantumdb.core.schema.operations.Operation;
 import io.quantumdb.core.utils.RandomHasher;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -22,6 +23,7 @@ import lombok.Setter;
  * This class allows you to define a series of successive ChangeSets, building up a changelog in the process.
  */
 @Data
+@EqualsAndHashCode(exclude = { "idGenerator" })
 public class Changelog {
 
 	private final Version root;

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
@@ -21,39 +21,39 @@ public class QuantumTables {
 
 			// Creates the "quantumdb_changelog" table which will store all the individual (schema) operations, and their ordering.
 			"CREATE TABLE quantumdb_changelog (version_id VARCHAR(10) NOT NULL, parent_version_id VARCHAR(10), operation_type VARCHAR(16), operation TEXT, PRIMARY KEY (version_id));",
-			"ALTER TABLE quantumdb_changelog ADD CONSTRAINT quantumdb_changelog_parent_version_id FOREIGN KEY (parent_version_id) REFERENCES quantumdb_changelog (version_id);",
+			"ALTER TABLE quantumdb_changelog ADD CONSTRAINT quantumdb_changelog_parent_version_id FOREIGN KEY (parent_version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;",
 			"ALTER TABLE quantumdb_changelog ADD CONSTRAINT quantumdb_changelog_no_self_reference CHECK (version_id != parent_version_id);",
 
 			// Creates the "quantumdb_changesets" table which describes all changesets - named lists of (schema) operations.
 			"CREATE TABLE quantumdb_changesets (version_id VARCHAR(10), author VARCHAR(255), created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), description TEXT, alias VARCHAR(255), PRIMARY KEY (version_id));",
-			"ALTER TABLE quantumdb_changesets ADD CONSTRAINT quantumdb_changesets_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id);",
+			"ALTER TABLE quantumdb_changesets ADD CONSTRAINT quantumdb_changesets_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;",
 
-			// Creates the "quantumdb_tableids" table which describes which virtual table name, is linked to which physical table name.
-			"CREATE TABLE quantumdb_tables (table_id VARCHAR(255) NOT NULL, table_name VARCHAR(255) NOT NULL, PRIMARY KEY (table_id));",
+			// Creates the "quantumdb_tableids" table which describes table ids exist.
+			"CREATE TABLE quantumdb_tables (table_id VARCHAR(255) NOT NULL, PRIMARY KEY (table_id));",
 
 			// Creates the "quantumdb_table_versions" table which describes which (physical) table exists at which version of the changelog.
-			"CREATE TABLE quantumdb_table_versions (table_id VARCHAR(255) NOT NULL, version_id VARCHAR(10) NOT NULL, PRIMARY KEY (table_id, version_id));",
-			"ALTER TABLE quantumdb_table_versions ADD CONSTRAINT quantumdb_table_versions_table_id FOREIGN KEY (table_id) REFERENCES quantumdb_tables (table_id);",
-			"ALTER TABLE quantumdb_table_versions ADD CONSTRAINT quantumdb_table_versions_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id);",
+			"CREATE TABLE quantumdb_table_versions (table_id VARCHAR(255) NOT NULL, version_id VARCHAR(10) NOT NULL, table_name VARCHAR(255) NOT NULL, PRIMARY KEY (table_id, version_id));",
+			"ALTER TABLE quantumdb_table_versions ADD CONSTRAINT quantumdb_table_versions_table_id FOREIGN KEY (table_id) REFERENCES quantumdb_tables (table_id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb_table_versions ADD CONSTRAINT quantumdb_table_versions_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;",
 
 			// Creates the "quantumdb_table_columns" table which describes which columns exist in the (physical) tables.
 			"CREATE SEQUENCE quantumdb_table_columns_id;",
 			"CREATE TABLE quantumdb_table_columns (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_table_columns_id'), table_id VARCHAR(255) NOT NULL, column_name VARCHAR(255) NOT NULL, PRIMARY KEY (id));",
-			"ALTER TABLE quantumdb_table_columns ADD CONSTRAINT quantumdb_table_columns_table_id FOREIGN KEY (table_id) REFERENCES quantumdb_tables (table_id);",
+			"ALTER TABLE quantumdb_table_columns ADD CONSTRAINT quantumdb_table_columns_table_id FOREIGN KEY (table_id) REFERENCES quantumdb_tables (table_id) ON DELETE CASCADE;",
 			"ALTER TABLE quantumdb_table_columns ADD CONSTRAINT quantumdb_table_columns_table_id_column_name_uniqueness UNIQUE (table_id, column_name);",
 
 			// Creates the "quantumdb_column_mappings" table which describes how columns are related to each other over time (ie prev/next version of the changelog).
 			"CREATE SEQUENCE quantumdb_column_mappings_id;",
 			"CREATE TABLE quantumdb_column_mappings (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_column_mappings_id'), source_column_id BIGINT NOT NULL, target_column_id BIGINT NOT NULL, PRIMARY KEY(id));",
-			"ALTER TABLE quantumdb_column_mappings ADD CONSTRAINT quantumdb_column_mappings_source_column_id FOREIGN KEY (source_column_id) REFERENCES quantumdb_table_columns (id);",
-			"ALTER TABLE quantumdb_column_mappings ADD CONSTRAINT quantumdb_column_mappings_target_column_id FOREIGN KEY (target_column_id) REFERENCES quantumdb_table_columns (id);",
+			"ALTER TABLE quantumdb_column_mappings ADD CONSTRAINT quantumdb_column_mappings_source_column_id FOREIGN KEY (source_column_id) REFERENCES quantumdb_table_columns (id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb_column_mappings ADD CONSTRAINT quantumdb_column_mappings_target_column_id FOREIGN KEY (target_column_id) REFERENCES quantumdb_table_columns (id) ON DELETE CASCADE;",
 			"ALTER TABLE quantumdb_column_mappings ADD CONSTRAINT quantumdb_column_mappings_source_target_uniqueness UNIQUE (source_column_id, target_column_id);",
 
 			// Creates the "quantumdb_synchronizers" table which describes which function and trigger is responsible for migrating data between a source and target table.
 			"CREATE SEQUENCE quantumdb_synchronizers_id;",
 			"CREATE TABLE quantumdb_synchronizers (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_synchronizers_id'), source_table_id VARCHAR(255) NOT NULL, target_table_id VARCHAR(255) NOT NULL, function_name VARCHAR(255) NOT NULL, trigger_name VARCHAR(255) NOT NULL, PRIMARY KEY(id));",
-			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_source_table_id FOREIGN KEY (source_table_id) REFERENCES quantumdb_tables (table_id);",
-			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_target_table_id FOREIGN KEY (target_table_id) REFERENCES quantumdb_tables (table_id);",
+			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_source_table_id FOREIGN KEY (source_table_id) REFERENCES quantumdb_tables (table_id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_target_table_id FOREIGN KEY (target_table_id) REFERENCES quantumdb_tables (table_id) ON DELETE CASCADE;",
 			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_source_target_uniqueness UNIQUE (source_table_id, target_table_id);",
 			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_unique_function_name UNIQUE (function_name);",
 			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_unique_trigger_name UNIQUE (trigger_name);",
@@ -61,8 +61,8 @@ public class QuantumTables {
 			// Creates the "quantumdb_synchronizer_columns" table which describes which columns are synchronized by a particular synchronizer.
 			"CREATE SEQUENCE quantumdb_synchronizer_columns_id;",
 			"CREATE TABLE quantumdb_synchronizer_columns (synchronizer_id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_synchronizer_columns_id'), column_mapping_id BIGINT NOT NULL, PRIMARY KEY(synchronizer_id, column_mapping_id));",
-			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_synchronizer_id FOREIGN KEY (synchronizer_id) REFERENCES quantumdb_synchronizers (id);",
-			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_column_mapping_id FOREIGN KEY (column_mapping_id) REFERENCES quantumdb_column_mappings (id);"
+			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_synchronizer_id FOREIGN KEY (synchronizer_id) REFERENCES quantumdb_synchronizers (id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_column_mapping_id FOREIGN KEY (column_mapping_id) REFERENCES quantumdb_column_mappings (id) ON DELETE CASCADE;"
 	);
 
 	public static int prepare(Connection connection) throws SQLException {
@@ -83,7 +83,7 @@ public class QuantumTables {
 					version++;
 					setVersion(connection, version);
 					connection.commit();
-					log.info("Updated meta-info tables to version: {}, took: {} ms", version, (end - start));
+					log.debug("Updated meta-info tables to version: {}, took: {} ms", version, (end - start));
 				}
 				catch (SQLException e) {
 					connection.rollback();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
@@ -101,7 +101,7 @@ public class QuantumTables {
 			Statement statement = connection.createStatement();
 			statement.executeUpdate("DROP SCHEMA public CASCADE;");
 			statement.executeUpdate("CREATE SCHEMA public;");
-			statement.executeUpdate("ALTER SCHEMA public OWNER TO CURRENT_USER;");
+			statement.executeUpdate("ALTER SCHEMA public OWNER TO " + connection.getMetaData().getUserName() + ";");
 			statement.close();
 			connection.commit();
 		}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/SyncFunctionTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/SyncFunctionTest.java
@@ -8,6 +8,7 @@ import static io.quantumdb.core.schema.operations.SchemaOperations.dropColumn;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
@@ -60,7 +61,8 @@ public class SyncFunctionTest {
 		refLog.addSync("some-name", "some-function", ImmutableMap.of(usersId, users2Id, usersName, users2Name));
 
 		NullRecords nullRecords = Mockito.mock(NullRecords.class);
-		SyncFunction syncFunction = new SyncFunction(refLog, source, target, catalog, nullRecords);
+		Map<ColumnRef, ColumnRef> columnMapping = refLog.getColumnMapping(source, target);
+		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("id", "name", "email"));
 
 		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
@@ -99,7 +101,8 @@ public class SyncFunctionTest {
 		refLog.addSync("some-name", "some-function", ImmutableMap.of(usersId, users2Id, usersName, users2Name));
 
 		NullRecords nullRecords = Mockito.mock(NullRecords.class);
-		SyncFunction syncFunction = new SyncFunction(refLog, source, target, catalog, nullRecords);
+		Map<ColumnRef, ColumnRef> columnMapping = refLog.getColumnMapping(source, target);
+		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("id", "full_name"));
 
 		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"full_name\"", "NEW.\"name\"")));
@@ -138,7 +141,8 @@ public class SyncFunctionTest {
 		refLog.addSync("some-name", "some-function", ImmutableMap.of(usersId, users2Id, usersName, users2Name));
 
 		NullRecords nullRecords = Mockito.mock(NullRecords.class);
-		SyncFunction syncFunction = new SyncFunction(refLog, source, target, catalog, nullRecords);
+		Map<ColumnRef, ColumnRef> columnMapping = refLog.getColumnMapping(source, target);
+		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("user_id", "name"));
 
 		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"user_id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
@@ -175,7 +179,8 @@ public class SyncFunctionTest {
 				Lists.newArrayList(users2Id, users2Name));
 
 		NullRecords nullRecords = Mockito.mock(NullRecords.class);
-		SyncFunction syncFunction = new SyncFunction(refLog, source, target, catalog, nullRecords);
+		Map<ColumnRef, ColumnRef> columnMapping = refLog.getColumnMapping(source, target);
+		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("id", "name"));
 
 		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
@@ -227,7 +232,8 @@ public class SyncFunctionTest {
 		NullRecords nullRecords = Mockito.mock(NullRecords.class);
 		Mockito.when(nullRecords.getIdentity(other)).thenReturn(new Identity("id", 0));
 
-		SyncFunction syncFunction = new SyncFunction(refLog, source, target, catalog, nullRecords);
+		Map<ColumnRef, ColumnRef> columnMapping = refLog.getColumnMapping(source, target);
+		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("id", "full_name"));
 
 		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"other_id\"", "0", "\"full_name\"", "NEW.\"name\"")));

--- a/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/multistate/MultiStateTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/backends/postgresql/integration/multistate/MultiStateTest.java
@@ -1,0 +1,79 @@
+package io.quantumdb.core.backends.postgresql.integration.multistate;
+
+import static io.quantumdb.core.backends.postgresql.PostgresTypes.bigint;
+import static io.quantumdb.core.backends.postgresql.PostgresTypes.bool;
+import static io.quantumdb.core.backends.postgresql.PostgresTypes.varchar;
+import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
+import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
+import static io.quantumdb.core.schema.operations.SchemaOperations.addColumn;
+import static io.quantumdb.core.schema.operations.SchemaOperations.createTable;
+import static io.quantumdb.core.schema.operations.SchemaOperations.execute;
+
+import java.sql.SQLException;
+
+import io.quantumdb.core.backends.Backend;
+import io.quantumdb.core.backends.Config;
+import io.quantumdb.core.backends.DatabaseMigrator.MigrationException;
+import io.quantumdb.core.backends.postgresql.PostgresqlDatabase;
+import io.quantumdb.core.migration.Migrator;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.State;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MultiStateTest extends PostgresqlDatabase {
+
+	private Backend backend;
+	private Version step0;
+	private Version step1;
+	private Version step4;
+
+	@Before
+	@Override
+	public void before() throws SQLException, ClassNotFoundException, MigrationException {
+		super.before();
+
+		Config config = new Config();
+		config.setUrl(getJdbcUrl());
+		config.setUser(getJdbcUser());
+		config.setPassword(getJdbcPass());
+		config.setCatalog(getCatalogName());
+		config.setDriver(getJdbcDriver());
+
+		backend = config.getBackend();
+
+		State state = backend.loadState();
+		Changelog changelog = state.getChangelog();
+
+		step0 = changelog.getRoot();
+
+		step1 = changelog.addChangeSet("Michael de Jong", "Create test table.",
+				createTable("test").with("id", bigint(), IDENTITY, AUTO_INCREMENT))
+				.getLastAdded();
+
+		changelog.addChangeSet("Michael de Jong", "Add name column to test table.",
+				addColumn("test", "name", varchar(255), "''", NOT_NULL))
+				.getLastAdded();
+
+		changelog.addChangeSet("Michael de Jong", "Insert default user account into test table.",
+				execute("INSERT INTO test (name) VALUES ('Hello');"))
+				.getLastAdded();
+
+		step4 = changelog.addChangeSet("Michael de Jong", "Created admin flag for test table.",
+				addColumn("test", "admin", bool(), "'false'", NOT_NULL))
+				.getLastAdded();
+
+		backend.persistState(state);
+	}
+
+	@Test
+	public void testMigratingOverDataChange() throws MigrationException {
+		Migrator migrator = new Migrator(backend);
+		migrator.migrate(step0.getId(), step1.getId());
+		migrator.migrate(step1.getId(), step4.getId());
+		migrator.drop(step1.getId());
+	}
+
+}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/VersionTraverserTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/VersionTraverserTest.java
@@ -1,0 +1,123 @@
+package io.quantumdb.core.migration;
+
+import static io.quantumdb.core.migration.VersionTraverser.findPath;
+import static io.quantumdb.core.migration.VersionTraverser.getDirection;
+import static io.quantumdb.core.migration.VersionTraverser.getFirst;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.quantumdb.core.migration.VersionTraverser.Direction;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class VersionTraverserTest {
+
+	private Version v1;
+	private Version v2;
+	private Version v3;
+	private Version v4;
+
+	@Before
+	public void setUp() {
+		this.v1 = new Version("1", null);
+		this.v2 = new Version("2", v1);
+		this.v3 = new Version("3", v2);
+		this.v4 = new Version("4", v3);
+	}
+
+	@Test
+	public void testGetDirectionBetweenRootAndV2() {
+		Direction direction = getDirection(v1, v2);
+		assertEquals(direction, Direction.FORWARDS);
+	}
+
+	@Test
+	public void testGetDirectionBetweenV2AndV3() {
+		Direction direction = getDirection(v3, v2);
+		assertEquals(direction, Direction.BACKWARDS);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetDirectionWithDuplicateInput() {
+		getDirection(v2, v2);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetDirectionWithNullAsFromInput() {
+		getDirection(null, v2);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetDirectionWithNullAsToInput() {
+		getDirection(v2, null);
+	}
+
+	@Test
+	public void testGetFirstIncludingRoot() {
+		Version first = getFirst(Sets.newHashSet(v1, v2));
+		assertEquals(v1, first);
+	}
+
+	@Test
+	public void testGetFirstExcludingRoot() {
+		Version first = getFirst(Sets.newHashSet(v2, v3));
+		assertEquals(v2, first);
+	}
+
+	@Test
+	public void testGetFirstOnGap() {
+		Version first = getFirst(Sets.newHashSet(v2, v4));
+		assertEquals(v2, first);
+	}
+
+	@Test
+	public void testGetFirstOnEmptySet() {
+		Version first = getFirst(Sets.newHashSet());
+		assertNull(first);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetFirstOnNullInput() {
+		getFirst(null);
+	}
+
+	@Test
+	public void testFindPath() {
+		List<Version> path = findPath(v1, v4).get();
+		assertEquals(Lists.newArrayList(v1, v2, v3, v4), path);
+	}
+
+	@Test
+	public void testFindingReversePath() {
+		List<Version> path = findPath(v4, v1).get();
+		assertEquals(Lists.newArrayList(v4, v3, v2, v1), path);
+	}
+
+	@Test
+	public void testFindingPathInDisconnectedChangelogsFails() {
+		Version vA = new Version("A", null);
+		Version vB = new Version("B", vA);
+		Version vC = new Version("C", vB);
+		Version vD = new Version("D", vC);
+
+		Optional<List<Version>> path = findPath(v1, vA);
+		assertEquals(Optional.empty(), path);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testFindingPathWithNullInputForOrigin() {
+		findPath(null, v4);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testFindingPathWithNullInputForTarget() {
+		findPath(v1, null);
+	}
+
+}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/RenameTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/RenameTableMigratorTest.java
@@ -51,7 +51,7 @@ public class RenameTableMigratorTest {
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
-		assertEquals("customers", refLog.getTableRefById(ghostTable.getName()).getName());
+		assertEquals("users", refLog.getTableRef(changelog.getLastAdded(), "customers").getTableId());
 		assertFalse(refLog.getTableRefs(changelog.getLastAdded()).stream()
 				.anyMatch(tableRef -> tableRef.getName().equals("users")));
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/state/RefLogTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/state/RefLogTest.java
@@ -268,11 +268,6 @@ public class RefLogTest {
 		refLog.addTable("transactions", generateHash(), null, Lists.newArrayList());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testAddingTableWithNullColumnsThrowsException() {
-		refLog.addTable("transactions", generateHash(), version, null);
-	}
-
 	@Test(expected = IllegalStateException.class)
 	public void testAddingTableWithExistingNameAndVersionCombinationThrowsException() {
 		refLog.addTable("users", generateHash(), version, Lists.newArrayList());

--- a/quantumdb-core/src/test/java/io/quantumdb/core/versioning/BackendTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/versioning/BackendTest.java
@@ -1,0 +1,87 @@
+package io.quantumdb.core.versioning;
+
+import static io.quantumdb.core.backends.postgresql.PostgresTypes.bigint;
+import static io.quantumdb.core.backends.postgresql.PostgresTypes.bool;
+import static io.quantumdb.core.backends.postgresql.PostgresTypes.text;
+import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
+import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
+import static io.quantumdb.core.schema.operations.SchemaOperations.addColumn;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.SQLException;
+
+import com.google.common.collect.ImmutableMap;
+import io.quantumdb.core.backends.postgresql.PostgresqlDatabase;
+import io.quantumdb.core.schema.definitions.Catalog;
+import io.quantumdb.core.schema.definitions.Column;
+import io.quantumdb.core.schema.definitions.Sequence;
+import io.quantumdb.core.schema.definitions.Table;
+import io.quantumdb.core.utils.RandomHasher;
+import io.quantumdb.core.versioning.RefLog.ColumnRef;
+import io.quantumdb.core.versioning.RefLog.TableRef;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BackendTest {
+
+	@Rule
+	public final PostgresqlDatabase database = new PostgresqlDatabase();
+
+	@Before
+	public void setUp() throws SQLException {
+		QuantumTables.prepare(database.createConnection());
+	}
+
+	@After
+	public void tearDown() throws SQLException {
+		QuantumTables.dropEverything(database.createConnection());
+	}
+
+	@Test
+	public void testPersistingAndLoadingSimpleTestCase() throws SQLException {
+		Sequence sequence = new Sequence("source_id_pk");
+		Catalog catalog = new Catalog("public")
+				.addSequence(sequence)
+				.addTable(new Table("table_1")
+						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, IDENTITY))
+						.addColumn(new Column("name", text(), NOT_NULL)))
+				.addTable(new Table("table_2")
+						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, IDENTITY))
+						.addColumn(new Column("name", text(), NOT_NULL))
+						.addColumn(new Column("admin", bool(), "false", NOT_NULL)));
+
+		Changelog changelog = new Changelog(RandomHasher.generateHash(), new ChangeSet("System", "Initial import"))
+				.addChangeSet("Michael de Jong", addColumn("table", "admin", bool(), "false", NOT_NULL));
+
+		RefLog refLog = new RefLog();
+		TableRef table1 = refLog.addTable("table", "table_1", changelog.getRoot(),
+				new ColumnRef("id"),
+				new ColumnRef("name"));
+
+		TableRef table2 = refLog.addTable("table", "table_2", changelog.getLastAdded(),
+				new ColumnRef("id", table1.getColumn("id")),
+				new ColumnRef("name", table1.getColumn("name")),
+				new ColumnRef("admin"));
+
+		refLog.addSync("trigger_1", "sync_1", ImmutableMap.<ColumnRef, ColumnRef>builder()
+				.put(table1.getColumn("id"), table2.getColumn("id"))
+				.put(table1.getColumn("name"), table2.getColumn("name"))
+				.build());
+
+		refLog.addSync("trigger_2", "sync_2", ImmutableMap.<ColumnRef, ColumnRef>builder()
+				.put(table2.getColumn("id"), table1.getColumn("id"))
+				.put(table2.getColumn("name"), table1.getColumn("name"))
+				.build());
+
+		Backend backend = new Backend();
+		State expectedState = new State(catalog, refLog, changelog);
+		backend.persist(database.createConnection(), expectedState);
+
+		State actualState = backend.load(database.getConnection(), catalog);
+		assertEquals(expectedState, actualState);
+	}
+
+}

--- a/quantumdb-driver/src/main/java/io/quantumdb/driver/Transformer.java
+++ b/quantumdb-driver/src/main/java/io/quantumdb/driver/Transformer.java
@@ -20,10 +20,9 @@ class Transformer {
 
 		if (version != null && !version.isEmpty()) {
 			String query = new StringBuilder()
-					.append("SELECT t.table_id, t.table_name ")
-					.append("FROM quantumdb_tables t ")
-					.append("LEFT JOIN quantumdb_table_versions v ON v.table_id = t.table_id ")
-					.append("WHERE v.version_id = ?;")
+					.append("SELECT table_id, table_name ")
+					.append("FROM quantumdb_table_versions ")
+					.append("WHERE version_id = ?;")
 					.toString();
 
 			try (PreparedStatement statement = connection.prepareStatement(query)) {


### PR DESCRIPTION
* Added a CLI main class for easier usage in the IDE.
* Removed several outdated TODOs.
* Reworked Version traversal.
* Reassign ownership of sequences when dropping tables.
* Create and drop intermediate tables when migrating data changes.
* Altered the way quantumdb data is stored and retrieved from the database.