### PR TITLE
Use Java 8 Lambda's in PrettyPrinter.java

### DIFF
--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/PrettyPrinter.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/PrettyPrinter.java
@@ -1,118 +1,96 @@
 package io.quantumdb.core.schema.definitions;
 
-import java.lang.reflect.Type;
-
 import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import io.quantumdb.core.schema.definitions.Column.Hint;
 
 class PrettyPrinter {
 
 	private static final Gson gson = new GsonBuilder()
-			.registerTypeAdapter(Catalog.class, new JsonSerializer<Catalog>() {
-				@Override
-				public JsonElement serialize(Catalog src, Type typeOfSrc, JsonSerializationContext context) {
-					JsonObject model = new JsonObject();
-					model.addProperty("catalogName", src.getName());
+			.registerTypeAdapter(Catalog.class, (JsonSerializer<Catalog>) (src, typeOfSrc, context) -> {
+				JsonObject model = new JsonObject();
+				model.addProperty("catalogName", src.getName());
 
-					JsonArray tables = new JsonArray();
-					src.getTables().stream()
-							.map(context::serialize)
-							.forEachOrdered(tables::add);
+				JsonArray tables = new JsonArray();
+				src.getTables().stream()
+						.map(context::serialize)
+						.forEachOrdered(tables::add);
 
-					JsonArray sequences = new JsonArray();
-					src.getSequences().stream()
-							.map(context::serialize)
-							.forEachOrdered(sequences::add);
+				JsonArray sequences = new JsonArray();
+				src.getSequences().stream()
+						.map(context::serialize)
+						.forEachOrdered(sequences::add);
 
-					model.add("tables", tables);
-					model.add("sequences", sequences);
-					return model;
-				}
+				model.add("tables", tables);
+				model.add("sequences", sequences);
+				return model;
 			})
-			.registerTypeAdapter(Column.class, new JsonSerializer<Column>() {
-				@Override
-				public JsonElement serialize(Column src, Type typeOfSrc, JsonSerializationContext context) {
-					JsonObject model = new JsonObject();
-					model.addProperty("columnName", src.getName());
-					model.addProperty("type", src.getType().getNotation());
-					model.addProperty("defaultValue", src.getDefaultValue());
+			.registerTypeAdapter(Column.class, (JsonSerializer<Column>) (src, typeOfSrc, context) -> {
+				JsonObject model = new JsonObject();
+				model.addProperty("columnName", src.getName());
+				model.addProperty("type", src.getType().getNotation());
+				model.addProperty("defaultValue", src.getDefaultValue());
 
-					if (!src.getHints().isEmpty()) {
-						JsonArray elements = new JsonArray();
-						src.getHints().stream()
-								.map(Hint::name)
-								.map(JsonPrimitive::new)
-								.forEachOrdered(elements::add);
+				if (!src.getHints().isEmpty()) {
+					JsonArray elements = new JsonArray();
+					src.getHints().stream()
+							.map(Hint::name)
+							.map(JsonPrimitive::new)
+							.forEachOrdered(elements::add);
 
-						model.add("hints", elements);
-					}
-					return model;
+					model.add("hints", elements);
 				}
+				return model;
 			})
-			.registerTypeAdapter(ForeignKey.class, new JsonSerializer<ForeignKey>() {
-				@Override
-				public JsonElement serialize(ForeignKey src, Type typeOfSrc, JsonSerializationContext context) {
-					JsonObject mapping = new JsonObject();
-					src.getColumnMapping().entrySet()
-							.forEach(entry -> mapping.addProperty(entry.getKey(), entry.getValue()));
+			.registerTypeAdapter(ForeignKey.class, (JsonSerializer<ForeignKey>) (src, typeOfSrc, context) -> {
+				JsonObject mapping = new JsonObject();
+				src.getColumnMapping().entrySet()
+						.forEach(entry -> mapping.addProperty(entry.getKey(), entry.getValue()));
 
-					JsonObject model = new JsonObject();
-					model.addProperty("name", src.getForeignKeyName());
-					model.addProperty("from", src.getReferencingTableName());
-					model.addProperty("to", src.getReferredTableName());
-					model.add("mapping", mapping);
-					model.addProperty("onUpdate", src.getOnUpdate().name());
-					model.addProperty("onDelete", src.getOnDelete().name());
-					return model;
-				}
+				JsonObject model = new JsonObject();
+				model.addProperty("name", src.getForeignKeyName());
+				model.addProperty("from", src.getReferencingTableName());
+				model.addProperty("to", src.getReferredTableName());
+				model.add("mapping", mapping);
+				model.addProperty("onUpdate", src.getOnUpdate().name());
+				model.addProperty("onDelete", src.getOnDelete().name());
+				return model;
 			})
-			.registerTypeAdapter(Sequence.class, new JsonSerializer<Sequence>() {
-				@Override
-				public JsonElement serialize(Sequence src, Type typeOfSrc, JsonSerializationContext context) {
-					JsonObject model = new JsonObject();
-					model.addProperty("sequenceName", src.getName());
-					return model;
-				}
+			.registerTypeAdapter(Sequence.class, (JsonSerializer<Sequence>) (src, typeOfSrc, context) -> {
+				JsonObject model = new JsonObject();
+				model.addProperty("sequenceName", src.getName());
+				return model;
 			})
-			.registerTypeAdapter(Index.class, new JsonSerializer<Index>() {
-				@Override
-				public JsonElement serialize(Index src, Type typeOfSrc, JsonSerializationContext context) {
-					JsonObject model = new JsonObject();
-					model.addProperty("indexName", src.getIndexName());
-					model.addProperty("table", src.getParent().getName());
-					model.addProperty("unique", src.isUnique());
-					model.addProperty("columns", Joiner.on(", ").join(src.getColumns()));
-					return model;
-				}
+			.registerTypeAdapter(Index.class, (JsonSerializer<Index>) (src, typeOfSrc, context) -> {
+				JsonObject model = new JsonObject();
+				model.addProperty("indexName", src.getIndexName());
+				model.addProperty("table", src.getParent().getName());
+				model.addProperty("unique", src.isUnique());
+				model.addProperty("columns", Joiner.on(", ").join(src.getColumns()));
+				return model;
 			})
-			.registerTypeAdapter(Table.class, new JsonSerializer<Table>() {
-				@Override
-				public JsonElement serialize(Table src, Type typeOfSrc, JsonSerializationContext context) {
-					JsonObject model = new JsonObject();
-					model.addProperty("tableName", src.getName());
+			.registerTypeAdapter(Table.class, (JsonSerializer<Table>) (src, typeOfSrc, context) -> {
+				JsonObject model = new JsonObject();
+				model.addProperty("tableName", src.getName());
 
-					JsonArray columns = new JsonArray();
-					src.getColumns().stream()
-							.map(context::serialize)
-							.forEachOrdered(columns::add);
+				JsonArray columns = new JsonArray();
+				src.getColumns().stream()
+						.map(context::serialize)
+						.forEachOrdered(columns::add);
 
-					JsonArray foreignKeys = new JsonArray();
-					src.getForeignKeys().stream()
-							.map(context::serialize)
-							.forEachOrdered(foreignKeys::add);
+				JsonArray foreignKeys = new JsonArray();
+				src.getForeignKeys().stream()
+						.map(context::serialize)
+						.forEachOrdered(foreignKeys::add);
 
-					model.add("columns", columns);
-					model.add("foreignKeys", foreignKeys);
-					return model;
-				}
+				model.add("columns", columns);
+				model.add("foreignKeys", foreignKeys);
+				return model;
 			})
 			.setPrettyPrinting()
 			.create();


### PR DESCRIPTION
Minor cleanup of the PrettyPrinter class, by using Java 8 lambdas instead of the anonymous inner class implementations for various `JsonSerializer`s.