### PR TITLE
Improve CLI logging to file.

### DIFF
--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -20,10 +21,14 @@ import io.quantumdb.cli.commands.Nuke;
 import io.quantumdb.cli.commands.Query;
 import io.quantumdb.cli.commands.Status;
 import io.quantumdb.cli.utils.CliWriter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class Main {
 
 	public static void main(String[] args) throws IOException, SQLException {
+		log.info("Parsing command: {}", Stream.of(args).collect(Collectors.joining(" ")));
+
 		CliWriter writer = new CliWriter();
 		List<String> arguments = normalize(args);
 

--- a/quantumdb-cli/src/main/resources/logback.xml
+++ b/quantumdb-cli/src/main/resources/logback.xml
@@ -2,15 +2,12 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
 	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<file>logs/server.log</file>
+		<file>logs/cli.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<!-- daily rollover -->
-			<fileNamePattern>logs/server.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-			<!-- keep 30 days' worth of history -->
+			<fileNamePattern>logs/cli.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
 			<maxHistory>15</maxHistory>
 			<timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-				<!-- or whenever the file size reaches 100MB -->
-				<maxFileSize>100MB</maxFileSize>
+				<maxFileSize>10MB</maxFileSize>
 			</timeBasedFileNamingAndTriggeringPolicy>
 		</rollingPolicy>
 
@@ -19,19 +16,10 @@
 		</encoder>
 	</appender>
 
-	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-
-		<!-- encoders are assigned by default the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
-		<encoder>
-			<pattern>%d{dd MMM HH:mm:ss.SSS} [%thread] %-5level %logger{36} \(%L\) - %msg%n</pattern>
-		</encoder>
-	</appender>
-
 	<logger name="io.quantumdb" level="DEBUG"/>
 
 	<root level="WARN">
 		<appender-ref ref="FILE" />
-		<appender-ref ref="STDOUT" />
 	</root>
 
 </configuration>


### PR DESCRIPTION
This PR improves how we log when using the command-line interface:

- Log to aptly named file (`logs/cli.log` instead of `logs/server.log`)
- No longer log to sysout or syserr, because these should show formatted errors to the user.