### PR TITLE
Track active versions separately in the RefLog

### DIFF
--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
@@ -62,8 +62,12 @@ public class QuantumTables {
 			"CREATE SEQUENCE quantumdb_synchronizer_columns_id;",
 			"CREATE TABLE quantumdb_synchronizer_columns (synchronizer_id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_synchronizer_columns_id'), column_mapping_id BIGINT NOT NULL, PRIMARY KEY(synchronizer_id, column_mapping_id));",
 			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_synchronizer_id FOREIGN KEY (synchronizer_id) REFERENCES quantumdb_synchronizers (id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_column_mapping_id FOREIGN KEY (column_mapping_id) REFERENCES quantumdb_column_mappings (id) ON DELETE CASCADE;"
-	);
+			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_column_mapping_id FOREIGN KEY (column_mapping_id) REFERENCES quantumdb_column_mappings (id) ON DELETE CASCADE;",
+
+			// Creates the "quantumdb_active_versions" table which describes which versions are active at this time.
+			"CREATE TABLE quantumdb_active_versions (version_id VARCHAR(10), PRIMARY KEY (version_id));",
+			"ALTER TABLE quantumdb_active_versions ADD CONSTRAINT quantumdb_active_versions_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;"
+		);
 
 	public static int prepare(Connection connection) throws SQLException {
 		connection.setAutoCommit(false);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/RefLog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/RefLog.java
@@ -369,12 +369,14 @@ public class RefLog {
 	}
 
 	private final Multimap<Version, TableRef> tables;
+	private final Set<Version> activeVersions;
 
 	/**
 	 * Creates a new RefLog object.
 	 */
 	public RefLog() {
 		this.tables = LinkedHashMultimap.create();
+		this.activeVersions = Sets.newHashSet();
 	}
 
 	/**
@@ -396,6 +398,10 @@ public class RefLog {
 			log.debug("Added TableRef: {} (id: {}) for version: {} with columns: {}", table.getName(),
 					table.getName(), version, tableRef.getColumns().keySet());
 		});
+
+		// Register version as active.
+		setVersionState(version, true);
+
 		return this;
 	}
 
@@ -702,11 +708,20 @@ public class RefLog {
 		return forwards;
 	}
 
+	public void setVersionState(Version version, boolean active) {
+		if (active) {
+			activeVersions.add(version);
+		}
+		else {
+			activeVersions.remove(version);
+		}
+	}
+
 	/**
 	 * @return An ImmutableSet of Versions covered by this RefLog.
 	 */
 	public ImmutableSet<Version> getVersions() {
-		return ImmutableSet.copyOf(tables.keySet());
+		return ImmutableSet.copyOf(activeVersions);
 	}
 
 }


### PR DESCRIPTION
We used to infer which versions were active from the RefLog data that was persisted to the database. The only problem was that since we started tracking intermediate versions in the RefLog/database as well, we also saw these intermediate versions as active. To solve this we now track each active version in a separate database table for the RefLog. 