### PR TITLE
Allow users to define the changelog using XML instead of Java, and use it from the CLI

### DIFF
--- a/docs/xml/ns/quantumdb-changelog-0.2.xsd
+++ b/docs/xml/ns/quantumdb-changelog-0.2.xsd
@@ -1,0 +1,202 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+			targetNamespace="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+			elementFormDefault="qualified">
+
+	<xsd:element name="changelog">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:choice minOccurs="0" maxOccurs="unbounded">
+					<xsd:element ref="changeset" minOccurs="0" maxOccurs="unbounded" />
+				</xsd:choice>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="changeset">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:sequence minOccurs="0" maxOccurs="1">
+					<xsd:element name="description" type="xsd:string" />
+				</xsd:sequence>
+				<xsd:element ref="operations" />
+			</xsd:sequence>
+			<xsd:attribute name="id" type="xsd:string" use="required"/>
+			<xsd:attribute name="author" type="xsd:string" use="required"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="operations">
+		<xsd:complexType>
+			<xsd:sequence minOccurs="1" maxOccurs="unbounded">
+				<xsd:choice>
+					<xsd:element ref="createTable" />
+					<xsd:element ref="dropTable" />
+					<xsd:element ref="renameTable" />
+					<xsd:element ref="copyTable" />
+
+					<xsd:element ref="addColumn" />
+					<xsd:element ref="dropColumn" />
+					<xsd:element ref="alterColumn" />
+					<xsd:element ref="alterDefaultExpression" />
+					<xsd:element ref="dropDefaultExpression" />
+
+					<xsd:element ref="createIndex" />
+					<xsd:element ref="dropIndex" />
+
+					<xsd:element ref="createForeignKey" />
+					<xsd:element ref="dropForeignKey" />
+
+					<xsd:element ref="sql" />
+				</xsd:choice>
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="createTable">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:sequence minOccurs="1" maxOccurs="1">
+					<xsd:element ref="columns" />
+				</xsd:sequence>
+			</xsd:sequence>
+			<xsd:attribute name="tableName" type="xsd:string" use="required"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="dropTable">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="renameTable">
+		<xsd:complexType>
+			<xsd:attribute name="oldTableName" type="xsd:string" use="required"/>
+			<xsd:attribute name="newTableName" type="xsd:string" use="required"/>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="copyTable">
+		<xsd:complexType>
+			<xsd:attribute name="sourceTableName" type="xsd:string" use="required"/>
+			<xsd:attribute name="targetTableName" type="xsd:string" use="required"/>
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="addColumn">
+		<xsd:complexType>
+			<xsd:sequence minOccurs="1" maxOccurs="1">
+				<xsd:element ref="column" />
+			</xsd:sequence>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="alterColumn">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+			<xsd:attribute name="columnName" type="xsd:string" use="required" />
+			<xsd:attribute name="newColumnName" type="xsd:string" />
+			<xsd:attribute name="newDataType" type="xsd:string" />
+			<xsd:attribute name="nullable" type="xsd:boolean" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="alterDefaultExpression">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+			<xsd:attribute name="columnName" type="xsd:string" use="required" />
+			<xsd:attribute name="defaultExpression" type="xsd:string" use="required" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="dropDefaultExpression">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+			<xsd:attribute name="columnName" type="xsd:string" use="required" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="dropColumn">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+			<xsd:attribute name="columnName" type="xsd:string" use="required" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="createIndex">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+			<xsd:attribute name="columnNames" type="xsd:string" use="required" />
+			<xsd:attribute name="unique" type="xsd:boolean" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="dropIndex">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+			<xsd:attribute name="columnNames" type="xsd:string" use="required" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="createForeignKey">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+			<xsd:attribute name="columnNames" type="xsd:string" use="required" />
+			<xsd:attribute name="referencesTableName" type="xsd:string" use="required" />
+			<xsd:attribute name="referencesColumnNames" type="xsd:string" use="required" />
+			<xsd:attribute name="name" type="xsd:string" />
+			<xsd:attribute name="onDelete" type="onDelete" />
+			<xsd:attribute name="onUpdate" type="onUpdate" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="dropForeignKey">
+		<xsd:complexType>
+			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+			<xsd:attribute name="foreignKeyName" type="xsd:string" use="required" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="sql" type="xsd:string" />
+
+	<xsd:element name="columns">
+		<xsd:complexType>
+			<xsd:sequence minOccurs="1" maxOccurs="unbounded">
+				<xsd:element ref="column" />
+			</xsd:sequence>
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:element name="column">
+		<xsd:complexType>
+			<xsd:attribute name="name" type="xsd:string" use="required" />
+			<xsd:attribute name="type" type="xsd:string" use="required" />
+			<xsd:attribute name="nullable" type="xsd:boolean" />
+			<xsd:attribute name="primaryKey" type="xsd:boolean" />
+			<xsd:attribute name="autoIncrement" type="xsd:boolean" />
+		</xsd:complexType>
+	</xsd:element>
+
+	<xsd:simpleType name="onDelete">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="CASCADE" />
+			<xsd:enumeration value="RESTRICT" />
+			<xsd:enumeration value="NO_ACTION" />
+			<xsd:enumeration value="SET_DEFAULT" />
+			<xsd:enumeration value="SET_NULL" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="onUpdate">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="CASCADE" />
+			<xsd:enumeration value="RESTRICT" />
+			<xsd:enumeration value="NO_ACTION" />
+			<xsd:enumeration value="SET_DEFAULT" />
+			<xsd:enumeration value="SET_NULL" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/quantumdb-cli/pom.xml
+++ b/quantumdb-cli/pom.xml
@@ -33,6 +33,16 @@
 			<artifactId>jline</artifactId>
 			<version>0.9.94</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>2.9.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.woodstox</groupId>
+			<artifactId>woodstox-core-asl</artifactId>
+			<version>4.4.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
@@ -60,7 +60,7 @@ public class Main {
 		writer.indent(-1);
 	}
 
-	private static LinkedHashMap<String, Command> listCommands() {
+	public static LinkedHashMap<String, Command> listCommands() {
 		List<Command> commands = Lists.newArrayList(
 				new Init(),
 				new Changelog(),

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
@@ -1,0 +1,58 @@
+package io.quantumdb.cli.xml;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ChangelogLoader {
+
+	public Changelog load(Changelog changelog, String file) throws IOException {
+		XmlChangelog xml = new XmlMapper().loadChangelog(file);
+		List<XmlChangeset> changesets = xml.getChangesets();
+
+		Version pointer = changelog.getRoot().getChild();
+		for (XmlChangeset changeset : changesets) {
+			String changesetId = changeset.getId();
+			if (pointer != null) {
+				for (int index = 1; index <= changeset.getOperations().size(); index++) {
+					XmlOperation<?> xmlOperation = changeset.getOperations().get(index - 1);
+					Operation operation = xmlOperation.toOperation();
+					Operation currentOperation = pointer.getOperation();
+
+					if (!operation.equals(currentOperation)) {
+						throw new IllegalStateException("Operation at index: " + index + " in changeset: "
+								+ changesetId + " differs from the one already defined in the database.");
+					}
+					if (!changesetId.equals(pointer.getChangeSet().getId())) {
+						throw new IllegalStateException("The changeset with id: " + changesetId + " was " +
+								"unexpected as the database already contains a different changeset in that position: "
+								+ pointer.getChangeSet().getId());
+					}
+
+					pointer = pointer.getChild();
+					if (pointer == null) {
+						break;
+					}
+				}
+			}
+			else {
+				String author = changeset.getAuthor();
+				String description = changeset.getDescription();
+				List<Operation> operations = changeset.getOperations().stream()
+						.map(XmlOperation::toOperation)
+						.collect(Collectors.toList());
+
+				changelog.addChangeSet(changesetId, author, description, operations);
+			}
+		}
+
+		return changelog;
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
@@ -1,0 +1,38 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.definitions.Column.Hint;
+import io.quantumdb.core.schema.operations.AddColumn;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlAddColumn implements XmlOperation<AddColumn> {
+
+	static final String TAG = "addColumn";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlAddColumn operation = new XmlAddColumn();
+		operation.setTableName(element.getAttributes().get("tableName"));
+
+		for (XmlElement child : element.getChildren()) {
+			if (child.getTag().equals("column")) {
+				operation.setColumn(XmlColumn.convert(child));
+			}
+		}
+
+		return operation;
+	}
+
+	private String tableName;
+	private XmlColumn column;
+
+	@Override
+	public AddColumn toOperation() {
+		return SchemaOperations.addColumn(tableName, column.getName(), null, new Hint[] {});
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddForeignKey.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddForeignKey.java
@@ -1,0 +1,61 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Optional;
+
+import io.quantumdb.core.schema.definitions.ForeignKey.Action;
+import io.quantumdb.core.schema.operations.AddForeignKey;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlAddForeignKey implements XmlOperation<AddForeignKey> {
+
+	static final String TAG = "addForeignKey";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlAddForeignKey operation = new XmlAddForeignKey();
+		operation.setTableName(element.getAttributes().get("tableName"));
+		operation.setColumnNames(element.getAttributes().get("columnNames").split(","));
+		operation.setReferencedTableName(element.getAttributes().get("referencesTableName"));
+		operation.setReferencedColumnNames(element.getAttributes().get("referencesColumnNames").split(","));
+
+		Optional.ofNullable(element.getAttributes().get("name"))
+				.ifPresent(operation::setName);
+
+		Optional.ofNullable(element.getAttributes().get("onDelete"))
+				.map(Action::valueOf)
+				.ifPresent(operation::setOnDelete);
+
+		Optional.ofNullable(element.getAttributes().get("onUpdate"))
+				.map(Action::valueOf)
+				.ifPresent(operation::setOnUpdate);
+
+		return operation;
+	}
+
+	private String tableName;
+	private String[] columnNames;
+	private String referencedTableName;
+	private String[] referencedColumnNames;
+
+	private String name;
+	private Action onDelete;
+	private Action onUpdate;
+
+	@Override
+	public AddForeignKey toOperation() {
+		AddForeignKey operation = SchemaOperations.addForeignKey(tableName, columnNames)
+				.referencing(referencedTableName, referencedColumnNames);
+
+		Optional.ofNullable(name).ifPresent(operation::named);
+		Optional.ofNullable(onDelete).ifPresent(operation::onDelete);
+		Optional.ofNullable(onUpdate).ifPresent(operation::onUpdate);
+
+		return operation;
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterColumn.java
@@ -1,0 +1,67 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.quantumdb.core.schema.definitions.Column.Hint;
+import io.quantumdb.core.schema.definitions.PostgresTypes;
+import io.quantumdb.core.schema.operations.AlterColumn;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlAlterColumn implements XmlOperation<AlterColumn> {
+
+	static final String TAG = "alterColumn";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+		Map<String, String> attributes = element.getAttributes();
+
+		XmlAlterColumn operation = new XmlAlterColumn();
+		operation.setTableName(attributes.get("tableName"));
+		operation.setColumnName(attributes.get("columnName"));
+
+		Optional.ofNullable(attributes.get("newColumnName"))
+				.ifPresent(operation::setNewColumnName);
+
+		Optional.ofNullable(attributes.get("newType"))
+				.ifPresent(operation::setNewType);
+
+		Optional.ofNullable(attributes.get("nullable"))
+				.map(Boolean.TRUE.toString()::equals)
+				.ifPresent(operation::setNullable);
+
+		return operation;
+	}
+
+	private String tableName;
+	private String columnName;
+
+	private String newColumnName;
+	private String newType;
+	private Boolean nullable;
+
+	@Override
+	public AlterColumn toOperation() {
+		AlterColumn operation = SchemaOperations.alterColumn(tableName, columnName);
+		Optional.ofNullable(newColumnName).ifPresent(operation::rename);
+		Optional.ofNullable(newType).map(PostgresTypes::from).ifPresent(operation::modifyDataType);
+
+		Optional.ofNullable(nullable).ifPresent(newNullable -> {
+			if (newNullable) {
+				operation.dropHint(Hint.NOT_NULL);
+			}
+			else {
+				operation.addHint(Hint.NOT_NULL);
+			}
+		});
+
+		// TODO: Support other hints?
+
+		return operation;
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterDefaultExpression.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterDefaultExpression.java
@@ -1,0 +1,37 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Map;
+
+import io.quantumdb.core.schema.operations.AlterColumn;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlAlterDefaultExpression implements XmlOperation<AlterColumn> {
+
+	static final String TAG = "alterDefaultExpression";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+		Map<String, String> attributes = element.getAttributes();
+
+		XmlAlterDefaultExpression operation = new XmlAlterDefaultExpression();
+		operation.setTableName(attributes.get("tableName"));
+		operation.setColumnName(attributes.get("columnName"));
+		operation.setDefaultExpression(attributes.get("defaultExpression"));
+		return operation;
+	}
+
+	private String tableName;
+	private String columnName;
+	private String defaultExpression;
+
+	@Override
+	public AlterColumn toOperation() {
+		return SchemaOperations.alterColumn(tableName, columnName)
+				.modifyDefaultExpression(defaultExpression);
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlChangelog.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlChangelog.java
@@ -1,0 +1,26 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import lombok.Data;
+
+@Data
+public class XmlChangelog {
+
+	static XmlChangelog convert(XmlElement element) {
+		checkArgument(element.getTag().equals("changelog"));
+
+		XmlChangelog changelog = new XmlChangelog();
+		for (XmlElement child : element.getChildren()) {
+			changelog.getChangesets().add(XmlChangeset.convert(child));
+		}
+
+		return changelog;
+	}
+
+	private final List<XmlChangeset> changesets = Lists.newArrayList();
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlChangeset.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlChangeset.java
@@ -1,0 +1,46 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+import lombok.Data;
+
+@Data
+public class XmlChangeset {
+
+	static XmlChangeset convert(XmlElement element) {
+		checkArgument(element.getTag().equals("changeset"));
+
+		XmlChangeset changeset = new XmlChangeset();
+		changeset.setId(element.getAttributes().get("id"));
+		changeset.setAuthor(element.getAttributes().get("author"));
+
+		for (XmlElement child : element.getChildren()) {
+			if (child.getTag().equals("operations")) {
+				for (XmlElement subChild : child.getChildren()) {
+					changeset.getOperations().add(XmlOperation.convert(subChild));
+				}
+			}
+			else if (child.getTag().equals("description")) {
+				String description = child.getChildren().stream()
+						.filter(subChild -> subChild.getTag() == null)
+						.filter(subChild -> subChild.getText() != null)
+						.map(XmlElement::getText)
+						.collect(Collectors.joining());
+
+				changeset.setDescription(description);
+			}
+		}
+
+		return changeset;
+	}
+
+	private String id;
+	private String author;
+	private String description;
+	private final List<XmlOperation<?>> operations = Lists.newArrayList();
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlColumn.java
@@ -1,0 +1,30 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import lombok.Data;
+
+@Data
+public class XmlColumn {
+
+	static XmlColumn convert(XmlElement element) {
+		checkArgument(element.getTag().equals("column"));
+
+		XmlColumn column = new XmlColumn();
+		column.setName(element.getAttributes().get("name"));
+		column.setType(element.getAttributes().get("type"));
+		column.setDefaultValue(element.getAttributes().get("defaultValue"));
+		column.setPrimaryKey(Boolean.TRUE.toString().equals(element.getAttributes().get("primaryKey")));
+		column.setAutoIncrement(Boolean.TRUE.toString().equals(element.getAttributes().get("autoIncrement")));
+		column.setNullable(Boolean.TRUE.toString().equals(element.getAttributes().get("nullable")));
+		return column;
+	}
+
+	private String name;
+	private String type;
+	private String defaultValue;
+	private boolean primaryKey;
+	private boolean autoIncrement;
+	private boolean nullable;
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCopyTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCopyTable.java
@@ -1,0 +1,31 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.operations.CopyTable;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlCopyTable implements XmlOperation<CopyTable> {
+
+	static final String TAG = "copyTable";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlCopyTable operation = new XmlCopyTable();
+		operation.setSourceTableName(element.getAttributes().get("sourceTableName"));
+		operation.setTargetTableName(element.getAttributes().get("targetTableName"));
+		return operation;
+	}
+
+	private String sourceTableName;
+	private String targetTableName;
+
+	@Override
+	public CopyTable toOperation() {
+		return SchemaOperations.copyTable(sourceTableName, targetTableName);
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateIndex.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateIndex.java
@@ -1,0 +1,39 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Optional;
+
+import io.quantumdb.core.schema.operations.CreateIndex;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlCreateIndex implements XmlOperation<CreateIndex> {
+
+	static final String TAG = "createIndex";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlCreateIndex operation = new XmlCreateIndex();
+		operation.setTableName(element.getAttributes().get("tableName"));
+		operation.setColumnNames(element.getAttributes().get("columnNames").split(","));
+
+		Optional.ofNullable(element.getAttributes().get("unique"))
+				.map(Boolean.TRUE.toString()::equals)
+				.ifPresent(operation::setUnique);
+
+		return operation;
+	}
+
+	private String tableName;
+	private String[] columnNames;
+	private boolean unique;
+
+	@Override
+	public CreateIndex toOperation() {
+		return SchemaOperations.createIndex(tableName, unique, columnNames);
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
@@ -1,0 +1,62 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import io.quantumdb.core.schema.definitions.Column.Hint;
+import io.quantumdb.core.schema.definitions.ColumnType;
+import io.quantumdb.core.schema.definitions.PostgresTypes;
+import io.quantumdb.core.schema.operations.CreateTable;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlCreateTable implements XmlOperation<CreateTable> {
+
+	static final String TAG = "createTable";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlCreateTable operation = new XmlCreateTable();
+		operation.setTableName(element.getAttributes().get("tableName"));
+
+		for (XmlElement child : element.getChildren()) {
+			if (child.getTag().equals("columns")) {
+				for (XmlElement subChild : child.getChildren()) {
+					operation.getColumns().add(XmlColumn.convert(subChild));
+				}
+			}
+		}
+
+		return operation;
+	}
+
+	private String tableName;
+	private final List<XmlColumn> columns = Lists.newArrayList();
+
+	@Override
+	public CreateTable toOperation() {
+		CreateTable operation = SchemaOperations.createTable(tableName);
+		for (XmlColumn column : columns) {
+			ColumnType type = PostgresTypes.from(column.getType());
+			String defaultValue = column.getDefaultValue();
+			List<Hint> hints = Lists.newArrayList();
+			if (column.isPrimaryKey()) {
+				hints.add(Hint.IDENTITY);
+			}
+			if (column.isAutoIncrement()) {
+				hints.add(Hint.AUTO_INCREMENT);
+			}
+			if (!column.isNullable()) {
+				hints.add(Hint.NOT_NULL);
+			}
+
+			operation.with(column.getName(), type, defaultValue, hints.toArray(new Hint[hints.size()]));
+		}
+		return operation;
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropColumn.java
@@ -1,0 +1,31 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.operations.DropColumn;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlDropColumn implements XmlOperation<DropColumn> {
+
+	static final String TAG = "dropColumn";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlDropColumn operation = new XmlDropColumn();
+		operation.setTableName(element.getAttributes().get("tableName"));
+		operation.setColumnName(element.getAttributes().get("columnName"));
+		return operation;
+	}
+
+	private String tableName;
+	private String columnName;
+
+	@Override
+	public DropColumn toOperation() {
+		return SchemaOperations.dropColumn(tableName, columnName);
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropDefaultExpression.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropDefaultExpression.java
@@ -1,0 +1,35 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Map;
+
+import io.quantumdb.core.schema.operations.AlterColumn;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlDropDefaultExpression implements XmlOperation<AlterColumn> {
+
+	static final String TAG = "dropDefaultExpression";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+		Map<String, String> attributes = element.getAttributes();
+
+		XmlDropDefaultExpression operation = new XmlDropDefaultExpression();
+		operation.setTableName(attributes.get("tableName"));
+		operation.setColumnName(attributes.get("columnName"));
+		return operation;
+	}
+
+	private String tableName;
+	private String columnName;
+
+	@Override
+	public AlterColumn toOperation() {
+		return SchemaOperations.alterColumn(tableName, columnName)
+				.dropDefaultExpression();
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropForeignKey.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropForeignKey.java
@@ -1,0 +1,31 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.operations.DropForeignKey;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlDropForeignKey implements XmlOperation<DropForeignKey> {
+
+	static final String TAG = "dropForeignKey";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlDropForeignKey operation = new XmlDropForeignKey();
+		operation.setTableName(element.getAttributes().get("tableName"));
+		operation.setForeignKeyName(element.getAttributes().get("foreignKeyName"));
+		return operation;
+	}
+
+	private String tableName;
+	private String foreignKeyName;
+
+	@Override
+	public DropForeignKey toOperation() {
+		return SchemaOperations.dropForeignKey(tableName, foreignKeyName);
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropIndex.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropIndex.java
@@ -1,0 +1,31 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.operations.DropIndex;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlDropIndex implements XmlOperation<DropIndex> {
+
+	static final String TAG = "dropIndex";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlDropIndex operation = new XmlDropIndex();
+		operation.setTableName(element.getAttributes().get("tableName"));
+		operation.setColumnNames(element.getAttributes().get("columnNames").split(","));
+		return operation;
+	}
+
+	private String tableName;
+	private String[] columnNames;
+
+	@Override
+	public DropIndex toOperation() {
+		return SchemaOperations.dropIndex(tableName, columnNames);
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropTable.java
@@ -1,0 +1,29 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.operations.DropTable;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlDropTable implements XmlOperation<DropTable> {
+
+	static final String TAG = "dropTable";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlDropTable operation = new XmlDropTable();
+		operation.setTableName(element.getAttributes().get("tableName"));
+		return operation;
+	}
+
+	private String tableName;
+
+	@Override
+	public DropTable toOperation() {
+		return SchemaOperations.dropTable(tableName);
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlElement.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlElement.java
@@ -1,0 +1,18 @@
+package io.quantumdb.cli.xml;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import lombok.Data;
+
+@Data
+class XmlElement {
+
+	private final String tag;
+	private final Map<String, String> attributes = Maps.newHashMap();
+	private final List<XmlElement> children = Lists.newArrayList();
+	private final String text;
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlMapper.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlMapper.java
@@ -1,0 +1,98 @@
+package io.quantumdb.cli.xml;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.collect.Lists;
+import lombok.SneakyThrows;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class XmlMapper {
+
+	public static void main(String[] args) throws IOException {
+		XmlChangelog changelog = new XmlMapper().loadChangelog("/changelog.xml");
+		System.out.println(changelog);
+	}
+
+	public XmlChangelog loadChangelog(String file) throws IOException {
+		XmlElement element = load(file);
+		return XmlChangelog.convert(element);
+	}
+
+	private XmlElement load(String file) throws IOException {
+		try {
+			SAXParserFactory factory = SAXParserFactory.newInstance();
+			SAXParser saxParser = factory.newSAXParser();
+
+			AtomicReference<XmlElement> result = new AtomicReference<>();
+			List<XmlElement> stack = Lists.newArrayList();
+			DefaultHandler handler = new DefaultHandler() {
+				@SneakyThrows
+				public void startElement(String uri, String localName, String qName, Attributes attributes) {
+					XmlElement element = new XmlElement(qName, null);
+					for (int i = 0; i < attributes.getLength(); i++) {
+						String key = attributes.getQName(i);
+						String value = attributes.getValue(i);
+						element.getAttributes().put(key, value);
+					}
+
+					if (stack.size() > 0) {
+						XmlElement parent = stack.get(stack.size() - 1);
+						parent.getChildren().add(element);
+					}
+
+					stack.add(element);
+				}
+
+				@SneakyThrows
+				public void endElement(String uri, String localName, String qName) {
+					XmlElement removed;
+					do {
+						removed = stack.remove(stack.size() - 1);
+					}
+					while (removed.getTag() == null);
+
+					if (!removed.getTag().equals(qName)) {
+						throw new SAXException("Unexpected closing tag: " + qName);
+					}
+
+					if (stack.isEmpty()) {
+						result.set(removed);
+					}
+				}
+
+				@SneakyThrows
+				public void characters(char ch[], int start, int length) {
+					String body = new String(ch, start, length);
+					if (body.trim().isEmpty()) {
+						return;
+					}
+
+					XmlElement element = new XmlElement(null, body);
+
+					if (stack.size() > 0) {
+						XmlElement parent = stack.get(stack.size() - 1);
+						parent.getChildren().add(element);
+					}
+
+					stack.add(element);
+				}
+			};
+
+			saxParser.parse(new File(file), handler);
+			return result.get();
+		}
+		catch (ParserConfigurationException | SAXException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlOperation.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlOperation.java
@@ -1,0 +1,43 @@
+package io.quantumdb.cli.xml;
+
+import io.quantumdb.core.schema.operations.Operation;
+
+public interface XmlOperation<T extends Operation> {
+
+	static XmlOperation<?> convert(XmlElement element) {
+		switch (element.getTag()) {
+			case XmlCreateTable.TAG:
+				return XmlCreateTable.convert(element);
+			case XmlDropTable.TAG:
+				return XmlDropTable.convert(element);
+			case XmlRenameTable.TAG:
+				return XmlRenameTable.convert(element);
+			case XmlCopyTable.TAG:
+				return XmlCopyTable.convert(element);
+			case XmlAddColumn.TAG:
+				return XmlAddColumn.convert(element);
+			case XmlAlterColumn.TAG:
+				return XmlAlterColumn.convert(element);
+			case XmlAlterDefaultExpression.TAG:
+				return XmlAlterDefaultExpression.convert(element);
+			case XmlDropDefaultExpression.TAG:
+				return XmlDropDefaultExpression.convert(element);
+			case XmlDropColumn.TAG:
+				return XmlDropColumn.convert(element);
+			case XmlAddForeignKey.TAG:
+				return XmlAddForeignKey.convert(element);
+			case XmlDropForeignKey.TAG:
+				return XmlDropForeignKey.convert(element);
+			case XmlCreateIndex.TAG:
+				return XmlCreateIndex.convert(element);
+			case XmlDropIndex.TAG:
+				return XmlDropIndex.convert(element);
+			case XmlQuery.TAG:
+				return XmlQuery.convert(element);
+			default:
+				throw new IllegalArgumentException("Unknown type of operation: " + element.getTag());
+		}
+	}
+
+	T toOperation();
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlQuery.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlQuery.java
@@ -1,0 +1,29 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.operations.DataOperation;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlQuery implements XmlOperation<DataOperation> {
+
+	static final String TAG = "sql";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlQuery operation = new XmlQuery();
+		operation.setQuery(element.getText());
+		return operation;
+	}
+
+	private String query;
+
+	@Override
+	public DataOperation toOperation() {
+		return SchemaOperations.execute(query);
+	}
+
+}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlRenameTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlRenameTable.java
@@ -1,0 +1,31 @@
+package io.quantumdb.cli.xml;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.operations.RenameTable;
+import io.quantumdb.core.schema.operations.SchemaOperations;
+import lombok.Data;
+
+@Data
+public class XmlRenameTable implements XmlOperation<RenameTable> {
+
+	static final String TAG = "renameTable";
+
+	static XmlOperation convert(XmlElement element) {
+		checkArgument(element.getTag().equals(TAG));
+
+		XmlRenameTable operation = new XmlRenameTable();
+		operation.setOldTableName(element.getAttributes().get("oldTableName"));
+		operation.setNewTableName(element.getAttributes().get("newTableName"));
+		return operation;
+	}
+
+	private String oldTableName;
+	private String newTableName;
+
+	@Override
+	public RenameTable toOperation() {
+		return SchemaOperations.renameTable(oldTableName, newTableName);
+	}
+
+}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/ChangeSet.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/ChangeSet.java
@@ -19,6 +19,8 @@ import lombok.Setter;
 @Data
 public class ChangeSet implements Comparable<ChangeSet> {
 
+	private final String id;
+
 	private final String author;
 
 	private final Date created;
@@ -33,8 +35,8 @@ public class ChangeSet implements Comparable<ChangeSet> {
 	 *
 	 * @param author The author of the ChangeSet.
 	 */
-	public ChangeSet(String author) {
-		this (author, null);
+	public ChangeSet(String id, String author) {
+		this (id, author, null);
 	}
 
 	/**
@@ -43,8 +45,8 @@ public class ChangeSet implements Comparable<ChangeSet> {
 	 * @param author The author of the ChangeSet.
 	 * @param description The description of the ChangeSet (may be NULL).
 	 */
-	public ChangeSet(String author, String description) {
-		this (author, new Date(), description);
+	public ChangeSet(String id, String author, String description) {
+		this (id, author, new Date(), description);
 	}
 
 	/**
@@ -54,10 +56,11 @@ public class ChangeSet implements Comparable<ChangeSet> {
 	 * @param created The time of creation of this ChangeSet.
 	 * @param description The description of the ChangeSet (may be NULL).
 	 */
-	ChangeSet(String author, Date created, String description) {
+	ChangeSet(String id, String author, Date created, String description) {
 		checkArgument(!isNullOrEmpty(author), "You must specify an 'author'.");
 		checkArgument(created != null, "You must specify a 'created' Date.");
 
+		this.id = id;
 		this.author = author;
 		this.created = created;
 		this.description = emptyToNull(description);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
@@ -61,20 +61,20 @@ public class Changelog {
 		}
 	}
 
-	public Changelog addChangeSet(String author, Collection<Operation> operations) {
-		return addChangeSet(lastAdded, new ChangeSet(author, new Date(), null), operations);
+	public Changelog addChangeSet(String id, String author, Collection<Operation> operations) {
+		return addChangeSet(lastAdded, new ChangeSet(id, author, new Date(), null), operations);
 	}
 
-	public Changelog addChangeSet(String author, Operation... operations) {
-		return addChangeSet(lastAdded, new ChangeSet(author, new Date(), null), operations);
+	public Changelog addChangeSet(String id, String author, Operation... operations) {
+		return addChangeSet(lastAdded, new ChangeSet(id, author, new Date(), null), operations);
 	}
 
-	public Changelog addChangeSet(String author, String description, Collection<Operation> operations) {
-		return addChangeSet(lastAdded, new ChangeSet(author, new Date(), description), operations);
+	public Changelog addChangeSet(String id, String author, String description, Collection<Operation> operations) {
+		return addChangeSet(lastAdded, new ChangeSet(id, author, new Date(), description), operations);
 	}
 
-	public Changelog addChangeSet(String author, String description, Operation... operations) {
-		return addChangeSet(lastAdded, new ChangeSet(author, new Date(), description), operations);
+	public Changelog addChangeSet(String id, String author, String description, Operation... operations) {
+		return addChangeSet(lastAdded, new ChangeSet(id, author, new Date(), description), operations);
 	}
 
 	public Changelog addChangeSet(ChangeSet changeSet, Collection<Operation> operations) {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
@@ -25,7 +25,8 @@ public class QuantumTables {
 			"ALTER TABLE quantumdb_changelog ADD CONSTRAINT quantumdb_changelog_no_self_reference CHECK (version_id != parent_version_id);",
 
 			// Creates the "quantumdb_changesets" table which describes all changesets - named lists of (schema) operations.
-			"CREATE TABLE quantumdb_changesets (version_id VARCHAR(10), author VARCHAR(255), created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), description TEXT, alias VARCHAR(255), PRIMARY KEY (version_id));",
+			"CREATE TABLE quantumdb_changesets (id VARCHAR(255), version_id VARCHAR(10), author VARCHAR(255), created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), description TEXT, alias VARCHAR(255), PRIMARY KEY (id));",
+			"ALTER TABLE quantumdb_changesets ADD CONSTRAINT quantumdb_changesets_version_id_unique UNIQUE (version_id);",
 			"ALTER TABLE quantumdb_changesets ADD CONSTRAINT quantumdb_changesets_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;",
 
 			// Creates the "quantumdb_tableids" table which describes table ids exist.

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/SchemaOperationMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/SchemaOperationMigratorTest.java
@@ -34,7 +34,7 @@ public class SchemaOperationMigratorTest {
 
 	@Test
 	public void testAddingNewTable() {
-		changelog.addChangeSet("Michael de Jong",
+		changelog.addChangeSet("test", "Michael de Jong",
 				createTable("users")
 						.with("id", bigint(), NOT_NULL, AUTO_INCREMENT, IDENTITY));
 

--- a/quantumdb-core/src/test/java/io/quantumdb/core/versioning/ChangeSetTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/versioning/ChangeSetTest.java
@@ -10,7 +10,7 @@ public class ChangeSetTest {
 
 	@Test
 	public void testSingleArgumentConstructor() {
-		ChangeSet changeSet = new ChangeSet("Michael de Jong");
+		ChangeSet changeSet = new ChangeSet("test", "Michael de Jong");
 
 		assertEquals("Michael de Jong", changeSet.getAuthor());
 		assertNull(changeSet.getDescription());
@@ -19,17 +19,17 @@ public class ChangeSetTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testThatSingleArgumentConstructorWithNullArgumentThrowsException() {
-		new ChangeSet(null);
+		new ChangeSet("test", null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testThatSingleArgumentConstructorWithEmptyStringArgumentThrowsException() {
-		new ChangeSet("");
+		new ChangeSet("test", "");
 	}
 
 	@Test
 	public void testThatDoubleArgumentConstructorWithNullArgumentIsAllowed() {
-		ChangeSet changeSet = new ChangeSet("Michael de Jong", null);
+		ChangeSet changeSet = new ChangeSet("test", "Michael de Jong", null);
 
 		assertEquals("Michael de Jong", changeSet.getAuthor());
 		assertNull(changeSet.getDescription());
@@ -38,7 +38,7 @@ public class ChangeSetTest {
 
 	@Test
 	public void testThatDoubleArgumentConstructorWithEmptyStringArgumentIsAllowed() {
-		ChangeSet changeSet = new ChangeSet("Michael de Jong", "");
+		ChangeSet changeSet = new ChangeSet("test", "Michael de Jong", "");
 
 		assertEquals("Michael de Jong", changeSet.getAuthor());
 		assertNull(changeSet.getDescription());
@@ -47,15 +47,15 @@ public class ChangeSetTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testThatTripleArgumentConstructorWithNullArgumentThrowsException() {
-		new ChangeSet("Michael de Jong", null, null);
+		new ChangeSet("test", "Michael de Jong", null, null);
 	}
 
 	@Test
 	public void testComparison() throws InterruptedException {
-		ChangeSet oldest = new ChangeSet("Michael de Jong");
+		ChangeSet oldest = new ChangeSet("test", "Michael de Jong");
 
 		Thread.sleep(100);
-		ChangeSet newest = new ChangeSet("Michael de Jong");
+		ChangeSet newest = new ChangeSet("test", "Michael de Jong");
 
 		assertEquals(-1, oldest.compareTo(newest));
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/versioning/ChangelogTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/versioning/ChangelogTest.java
@@ -43,7 +43,7 @@ public class ChangelogTest {
 	public void testAddingChangeSet() {
 		Changelog changelog = new Changelog();
 		RenameTable renameTable = SchemaOperations.renameTable("users", "customers");
-		changelog.addChangeSet("Michael de Jong", renameTable);
+		changelog.addChangeSet("test", "Michael de Jong", renameTable);
 
 		Version version = changelog.getLastAdded();
 		Version lookup = changelog.getVersion(version.getId());

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
@@ -293,6 +293,9 @@ class CatalogLoader {
 
 				parser.expect("ON");
 				String indexTableName = parser.consume();
+				if (indexTableName.startsWith("public.")) {
+					indexTableName = indexTableName.substring("public.".length());
+				}
 
 				if (parser.present("USING")) {
 					parser.consume();

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
@@ -3,12 +3,27 @@ package io.quantumdb.core.schema.definitions;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostgresTypes {
+
+	public static ColumnType from(String input) {
+		Pattern pattern = Pattern.compile("^(.+)\\(([0-9]+)\\)$");
+		Matcher match = pattern.matcher(input);
+		if (match.find()) {
+			String type = match.group(1);
+			int length = Integer.parseInt(match.group(2));
+			return from(type, length);
+		}
+		else {
+			return from(input, null);
+		}
+	}
 
 	public static ColumnType from(String type, Integer length) {
 		switch (type.toLowerCase()) {

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
@@ -49,19 +49,19 @@ public class MultiStateTest extends PostgresqlDatabase {
 
 		step0 = changelog.getRoot();
 
-		step1 = changelog.addChangeSet("Michael de Jong", "Create test table.",
+		step1 = changelog.addChangeSet("step1", "Michael de Jong", "Create test table.",
 				createTable("test").with("id", bigint(), IDENTITY, AUTO_INCREMENT))
 				.getLastAdded();
 
-		changelog.addChangeSet("Michael de Jong", "Add name column to test table.",
+		changelog.addChangeSet("step2", "Michael de Jong", "Add name column to test table.",
 				addColumn("test", "name", varchar(255), "''", NOT_NULL))
 				.getLastAdded();
 
-		changelog.addChangeSet("Michael de Jong", "Insert default user account into test table.",
+		changelog.addChangeSet("step3", "Michael de Jong", "Insert default user account into test table.",
 				execute("INSERT INTO test (name) VALUES ('Hello');"))
 				.getLastAdded();
 
-		step4 = changelog.addChangeSet("Michael de Jong", "Created admin flag for test table.",
+		step4 = changelog.addChangeSet("step4", "Michael de Jong", "Created admin flag for test table.",
 				addColumn("test", "admin", bool(), "'false'", NOT_NULL))
 				.getLastAdded();
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
@@ -49,7 +49,7 @@ public class AddColumnToCustomersTable {
 
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.addColumn("customers", "date_of_birth", date()));
 
 		target = setup.getChangelog().getLastAdded();

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
@@ -47,7 +47,7 @@ public class AddColumnToFilmsTable {
 	public static void performEvolution() throws SQLException, MigrationException {
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.addColumn("films", "release_date", date()));
 
 		target = setup.getChangelog().getLastAdded();

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
@@ -48,7 +48,7 @@ public class AddColumnToPaymentsTable {
 	public static void performEvolution() throws SQLException, MigrationException {
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.addColumn("payments", "verified", bool(), "'false'", NOT_NULL));
 
 		target = setup.getChangelog().getLastAdded();

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
@@ -49,7 +49,7 @@ public class AddForeignKeyToPaymentsTable {
 
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.addColumn("payments", "store_id", integer(), "'1'", NOT_NULL),
 				SchemaOperations.addForeignKey("payments", "store_id").referencing("stores", "id"));
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
@@ -49,7 +49,7 @@ public class CopyCustomersTable {
 
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.copyTable("customers", "customers_backup"));
 
 		target = setup.getChangelog().getLastAdded();

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
@@ -49,7 +49,7 @@ public class CreateCreditCardsTable {
 
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.createTable("credit_cards")
 						.with("credit_card_number", varchar(255), IDENTITY, NOT_NULL)
 						.with("card_holder_name", varchar(255), NOT_NULL)

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
@@ -47,7 +47,7 @@ public class DropColumnFromCustomersTable {
 	public static void performEvolution() throws SQLException, MigrationException {
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.dropColumn("customers", "referred_by"));
 
 		target = setup.getChangelog().getLastAdded();

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
@@ -49,7 +49,7 @@ public class DropForeignKeyFromCustomersTable {
 
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.dropForeignKey("customers", "customer_registered_at_store"));
 
 		target = setup.getChangelog().getLastAdded();

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
@@ -46,7 +46,7 @@ public class DropPaymentsTable {
 	public static void performEvolution() throws SQLException, MigrationException {
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.dropTable("payments"));
 
 		target = setup.getChangelog().getLastAdded();

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
@@ -43,7 +43,7 @@ public class MakeStoreFieldInStaffTableNullable {
 
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.alterColumn("staff", "store_id")
 						.modifyDefaultExpression("NULL")
 						.dropHint(NOT_NULL));

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
@@ -48,7 +48,7 @@ public class ModifyTypeInPaymentsTable {
 	public static void performEvolution() throws SQLException, MigrationException {
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.alterColumn("payments", "amount")
 						.modifyDataType(doubles()));
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
@@ -50,7 +50,7 @@ public class RenameCustomersTable {
 	public static void performEvolution() throws SQLException, MigrationException {
 		origin = setup.getChangelog().getLastAdded();
 
-		setup.getChangelog().addChangeSet("Michael de Jong",
+		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.renameTable("customers", "clients"));
 
 		target = setup.getChangelog().getLastAdded();

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/GreedyMigrationPlannerTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/GreedyMigrationPlannerTest.java
@@ -1345,7 +1345,7 @@ public class GreedyMigrationPlannerTest {
 		this.refLog = RefLog.init(catalog, changelog.getRoot());
 		State state = new State(catalog, refLog, changelog);
 
-		changelog.addChangeSet("Michael de Jong", operation);
+		changelog.addChangeSet("test", "Michael de Jong", operation);
 
 		PostgresqlMigrationPlanner planner = new PostgresqlMigrationPlanner();
 		this.plan = planner.createPlan(state, changelog.getRoot(), changelog.getLastAdded());

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/SyncFunctionTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/SyncFunctionTest.java
@@ -48,7 +48,7 @@ public class SyncFunctionTest {
 		catalog.addTable(ghost);
 
 		Changelog changelog = new Changelog();
-		changelog.addChangeSet("Michael de Jong", SchemaOperations.addColumn("users", "email", varchar(255)));
+		changelog.addChangeSet("test", "Michael de Jong", SchemaOperations.addColumn("users", "email", varchar(255)));
 		RefLog refLog = new RefLog();
 
 		ColumnRef usersId = new ColumnRef("id");
@@ -88,7 +88,7 @@ public class SyncFunctionTest {
 		catalog.addTable(ghost);
 
 		Changelog changelog = new Changelog();
-		changelog.addChangeSet("Michael de Jong", alterColumn("users", "name").rename("full_name"));
+		changelog.addChangeSet("test", "Michael de Jong", alterColumn("users", "name").rename("full_name"));
 		RefLog refLog = new RefLog();
 
 		ColumnRef usersId = new ColumnRef("id");
@@ -128,7 +128,7 @@ public class SyncFunctionTest {
 		catalog.addTable(ghost);
 
 		Changelog changelog = new Changelog();
-		changelog.addChangeSet("Michael de Jong", alterColumn("users", "id").rename("user_id"));
+		changelog.addChangeSet("test", "Michael de Jong", alterColumn("users", "id").rename("user_id"));
 		RefLog refLog = new RefLog();
 
 		ColumnRef usersId = new ColumnRef("id");
@@ -168,7 +168,7 @@ public class SyncFunctionTest {
 		catalog.addTable(ghost);
 
 		Changelog changelog = new Changelog();
-		changelog.addChangeSet("Michael de Jong", alterColumn("users", "name").addHint(NOT_NULL));
+		changelog.addChangeSet("test", "Michael de Jong", alterColumn("users", "name").addHint(NOT_NULL));
 		RefLog refLog = new RefLog();
 
 		ColumnRef usersId = new ColumnRef("id");
@@ -216,8 +216,8 @@ public class SyncFunctionTest {
 		catalog.addTable(ghost);
 
 		Changelog changelog = new Changelog();
-		changelog.addChangeSet("Michael de Jong", dropColumn("users", "other_id"));
-		changelog.addChangeSet("Michael de Jong", alterColumn("users", "name").rename("full_name").addHint(NOT_NULL));
+		changelog.addChangeSet("test1", "Michael de Jong", dropColumn("users", "other_id"));
+		changelog.addChangeSet("test2", "Michael de Jong", alterColumn("users", "name").rename("full_name").addHint(NOT_NULL));
 		RefLog refLog = new RefLog();
 
 		ColumnRef usersId = new ColumnRef("id");

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/versioning/BackendTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/versioning/BackendTest.java
@@ -1,11 +1,11 @@
 package io.quantumdb.core.versioning;
 
-import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
-import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
-import static io.quantumdb.core.schema.definitions.PostgresTypes.text;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
 import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
+import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
+import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
+import static io.quantumdb.core.schema.definitions.PostgresTypes.text;
 import static io.quantumdb.core.schema.operations.SchemaOperations.addColumn;
 import static org.junit.Assert.assertEquals;
 
@@ -53,8 +53,8 @@ public class BackendTest {
 						.addColumn(new Column("name", text(), NOT_NULL))
 						.addColumn(new Column("admin", bool(), "false", NOT_NULL)));
 
-		Changelog changelog = new Changelog(RandomHasher.generateHash(), new ChangeSet("System", "Initial import"))
-				.addChangeSet("Michael de Jong", addColumn("table", "admin", bool(), "false", NOT_NULL));
+		Changelog changelog = new Changelog(RandomHasher.generateHash(), new ChangeSet("init", "QuantumDB", "Initial import"))
+				.addChangeSet("add_table", "Michael de Jong", addColumn("table", "admin", bool(), "false", NOT_NULL));
 
 		RefLog refLog = new RefLog();
 		TableRef table1 = refLog.addTable("table", "table_1", changelog.getRoot(),


### PR DESCRIPTION
This PR introduces a method for users to define the changelog in an XML file, and load it with the CLI tool. From there the CLI can persist it into the database, and fork the database schema as if the changelog was already previously defined. Sould the changelog in the XML file differ (in terms of previously existing changesets) from those defined in the database, then an error will be presented to the user.