### PR TITLE
Store quantumdb meta tables in separate schema.

### DIFF
--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Nuke.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Nuke.java
@@ -24,10 +24,12 @@ public class Nuke extends Command {
 		Config config = Config.load();
 
 		Backend backend = config.getBackend();
+
 		try {
 			try (Connection connection = backend.connect()) {
-				QuantumTables.dropEverything(connection);
+				QuantumTables.dropEverything(connection, "public");
 			}
+			writer.write("Successfully dropped everything!", Context.SUCCESS);
 		}
 		catch (SQLException e) {
 			writer.write(e.getMessage(), Context.FAILURE);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/QuantumTables.java
@@ -16,58 +16,58 @@ public class QuantumTables {
 	private static final String VERSION_KEY = "meta_info_version";
 
 	private static final List<String> CHANGES = Lists.newArrayList(
-			// Creates the "quantumdb_config" table to store persistent configuration and meta info in.
-			"CREATE TABLE quantumdb_config (name VARCHAR(255) NOT NULL, value VARCHAR(255) NOT NULL, PRIMARY KEY (name));",
+			// Creates the "config" table to store persistent configuration and meta info in.
+			"CREATE TABLE quantumdb.config (name VARCHAR(255) NOT NULL, value VARCHAR(255) NOT NULL, PRIMARY KEY (name));",
 
-			// Creates the "quantumdb_changelog" table which will store all the individual (schema) operations, and their ordering.
-			"CREATE TABLE quantumdb_changelog (version_id VARCHAR(10) NOT NULL, parent_version_id VARCHAR(10), operation_type VARCHAR(16), operation TEXT, PRIMARY KEY (version_id));",
-			"ALTER TABLE quantumdb_changelog ADD CONSTRAINT quantumdb_changelog_parent_version_id FOREIGN KEY (parent_version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_changelog ADD CONSTRAINT quantumdb_changelog_no_self_reference CHECK (version_id != parent_version_id);",
+			// Creates the "changelog" table which will store all the individual (schema) operations, and their ordering.
+			"CREATE TABLE quantumdb.changelog (version_id VARCHAR(10) NOT NULL, parent_version_id VARCHAR(10), operation_type VARCHAR(16), operation TEXT, PRIMARY KEY (version_id));",
+			"ALTER TABLE quantumdb.changelog ADD CONSTRAINT changelog_parent_version_id FOREIGN KEY (parent_version_id) REFERENCES quantumdb.changelog (version_id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb.changelog ADD CONSTRAINT changelog_no_self_reference CHECK (version_id != parent_version_id);",
 
-			// Creates the "quantumdb_changesets" table which describes all changesets - named lists of (schema) operations.
-			"CREATE TABLE quantumdb_changesets (id VARCHAR(255), version_id VARCHAR(10), author VARCHAR(255), created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), description TEXT, alias VARCHAR(255), PRIMARY KEY (id));",
-			"ALTER TABLE quantumdb_changesets ADD CONSTRAINT quantumdb_changesets_version_id_unique UNIQUE (version_id);",
-			"ALTER TABLE quantumdb_changesets ADD CONSTRAINT quantumdb_changesets_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;",
+			// Creates the "changesets" table which describes all changesets - named lists of (schema) operations.
+			"CREATE TABLE quantumdb.changesets (id VARCHAR(255), version_id VARCHAR(10), author VARCHAR(255), created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), description TEXT, alias VARCHAR(255), PRIMARY KEY (id));",
+			"ALTER TABLE quantumdb.changesets ADD CONSTRAINT changesets_version_id_unique UNIQUE (version_id);",
+			"ALTER TABLE quantumdb.changesets ADD CONSTRAINT changesets_version_id FOREIGN KEY (version_id) REFERENCES quantumdb.changelog (version_id) ON DELETE CASCADE;",
 
-			// Creates the "quantumdb_tableids" table which describes table ids exist.
-			"CREATE TABLE quantumdb_tables (table_id VARCHAR(255) NOT NULL, PRIMARY KEY (table_id));",
+			// Creates the "tableids" table which describes table ids exist.
+			"CREATE TABLE quantumdb.tables (table_id VARCHAR(255) NOT NULL, PRIMARY KEY (table_id));",
 
-			// Creates the "quantumdb_table_versions" table which describes which (physical) table exists at which version of the changelog.
-			"CREATE TABLE quantumdb_table_versions (table_id VARCHAR(255) NOT NULL, version_id VARCHAR(10) NOT NULL, table_name VARCHAR(255) NOT NULL, PRIMARY KEY (table_id, version_id));",
-			"ALTER TABLE quantumdb_table_versions ADD CONSTRAINT quantumdb_table_versions_table_id FOREIGN KEY (table_id) REFERENCES quantumdb_tables (table_id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_table_versions ADD CONSTRAINT quantumdb_table_versions_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;",
+			// Creates the "table_versions" table which describes which (physical) table exists at which version of the changelog.
+			"CREATE TABLE quantumdb.table_versions (table_id VARCHAR(255) NOT NULL, version_id VARCHAR(10) NOT NULL, table_name VARCHAR(255) NOT NULL, PRIMARY KEY (table_id, version_id));",
+			"ALTER TABLE quantumdb.table_versions ADD CONSTRAINT table_versions_table_id FOREIGN KEY (table_id) REFERENCES quantumdb.tables (table_id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb.table_versions ADD CONSTRAINT table_versions_version_id FOREIGN KEY (version_id) REFERENCES quantumdb.changelog (version_id) ON DELETE CASCADE;",
 
-			// Creates the "quantumdb_table_columns" table which describes which columns exist in the (physical) tables.
-			"CREATE SEQUENCE quantumdb_table_columns_id;",
-			"CREATE TABLE quantumdb_table_columns (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_table_columns_id'), table_id VARCHAR(255) NOT NULL, column_name VARCHAR(255) NOT NULL, PRIMARY KEY (id));",
-			"ALTER TABLE quantumdb_table_columns ADD CONSTRAINT quantumdb_table_columns_table_id FOREIGN KEY (table_id) REFERENCES quantumdb_tables (table_id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_table_columns ADD CONSTRAINT quantumdb_table_columns_table_id_column_name_uniqueness UNIQUE (table_id, column_name);",
+			// Creates the "table_columns" table which describes which columns exist in the (physical) tables.
+			"CREATE SEQUENCE quantumdb.table_columns_id;",
+			"CREATE TABLE quantumdb.table_columns (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb.table_columns_id'), table_id VARCHAR(255) NOT NULL, column_name VARCHAR(255) NOT NULL, PRIMARY KEY (id));",
+			"ALTER TABLE quantumdb.table_columns ADD CONSTRAINT table_columns_table_id FOREIGN KEY (table_id) REFERENCES quantumdb.tables (table_id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb.table_columns ADD CONSTRAINT table_columns_table_id_column_name_uniqueness UNIQUE (table_id, column_name);",
 
-			// Creates the "quantumdb_column_mappings" table which describes how columns are related to each other over time (ie prev/next version of the changelog).
-			"CREATE SEQUENCE quantumdb_column_mappings_id;",
-			"CREATE TABLE quantumdb_column_mappings (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_column_mappings_id'), source_column_id BIGINT NOT NULL, target_column_id BIGINT NOT NULL, PRIMARY KEY(id));",
-			"ALTER TABLE quantumdb_column_mappings ADD CONSTRAINT quantumdb_column_mappings_source_column_id FOREIGN KEY (source_column_id) REFERENCES quantumdb_table_columns (id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_column_mappings ADD CONSTRAINT quantumdb_column_mappings_target_column_id FOREIGN KEY (target_column_id) REFERENCES quantumdb_table_columns (id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_column_mappings ADD CONSTRAINT quantumdb_column_mappings_source_target_uniqueness UNIQUE (source_column_id, target_column_id);",
+			// Creates the "column_mappings" table which describes how columns are related to each other over time (ie prev/next version of the changelog).
+			"CREATE SEQUENCE quantumdb.column_mappings_id;",
+			"CREATE TABLE quantumdb.column_mappings (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb.column_mappings_id'), source_column_id BIGINT NOT NULL, target_column_id BIGINT NOT NULL, PRIMARY KEY(id));",
+			"ALTER TABLE quantumdb.column_mappings ADD CONSTRAINT column_mappings_source_column_id FOREIGN KEY (source_column_id) REFERENCES quantumdb.table_columns (id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb.column_mappings ADD CONSTRAINT column_mappings_target_column_id FOREIGN KEY (target_column_id) REFERENCES quantumdb.table_columns (id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb.column_mappings ADD CONSTRAINT column_mappings_source_target_uniqueness UNIQUE (source_column_id, target_column_id);",
 
-			// Creates the "quantumdb_synchronizers" table which describes which function and trigger is responsible for migrating data between a source and target table.
-			"CREATE SEQUENCE quantumdb_synchronizers_id;",
-			"CREATE TABLE quantumdb_synchronizers (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_synchronizers_id'), source_table_id VARCHAR(255) NOT NULL, target_table_id VARCHAR(255) NOT NULL, function_name VARCHAR(255) NOT NULL, trigger_name VARCHAR(255) NOT NULL, PRIMARY KEY(id));",
-			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_source_table_id FOREIGN KEY (source_table_id) REFERENCES quantumdb_tables (table_id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_target_table_id FOREIGN KEY (target_table_id) REFERENCES quantumdb_tables (table_id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_source_target_uniqueness UNIQUE (source_table_id, target_table_id);",
-			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_unique_function_name UNIQUE (function_name);",
-			"ALTER TABLE quantumdb_synchronizers ADD CONSTRAINT quantumdb_synchronizers_unique_trigger_name UNIQUE (trigger_name);",
+			// Creates the "synchronizers" table which describes which function and trigger is responsible for migrating data between a source and target table.
+			"CREATE SEQUENCE quantumdb.synchronizers_id;",
+			"CREATE TABLE quantumdb.synchronizers (id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb.synchronizers_id'), source_table_id VARCHAR(255) NOT NULL, target_table_id VARCHAR(255) NOT NULL, function_name VARCHAR(255) NOT NULL, trigger_name VARCHAR(255) NOT NULL, PRIMARY KEY(id));",
+			"ALTER TABLE quantumdb.synchronizers ADD CONSTRAINT synchronizers_source_table_id FOREIGN KEY (source_table_id) REFERENCES quantumdb.tables (table_id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb.synchronizers ADD CONSTRAINT synchronizers_target_table_id FOREIGN KEY (target_table_id) REFERENCES quantumdb.tables (table_id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb.synchronizers ADD CONSTRAINT synchronizers_source_target_uniqueness UNIQUE (source_table_id, target_table_id);",
+			"ALTER TABLE quantumdb.synchronizers ADD CONSTRAINT synchronizers_unique_function_name UNIQUE (function_name);",
+			"ALTER TABLE quantumdb.synchronizers ADD CONSTRAINT synchronizers_unique_trigger_name UNIQUE (trigger_name);",
 
-			// Creates the "quantumdb_synchronizer_columns" table which describes which columns are synchronized by a particular synchronizer.
-			"CREATE SEQUENCE quantumdb_synchronizer_columns_id;",
-			"CREATE TABLE quantumdb_synchronizer_columns (synchronizer_id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb_synchronizer_columns_id'), column_mapping_id BIGINT NOT NULL, PRIMARY KEY(synchronizer_id, column_mapping_id));",
-			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_synchronizer_id FOREIGN KEY (synchronizer_id) REFERENCES quantumdb_synchronizers (id) ON DELETE CASCADE;",
-			"ALTER TABLE quantumdb_synchronizer_columns ADD CONSTRAINT quantumdb_synchronizer_columns_column_mapping_id FOREIGN KEY (column_mapping_id) REFERENCES quantumdb_column_mappings (id) ON DELETE CASCADE;",
+			// Creates the "synchronizer_columns" table which describes which columns are synchronized by a particular synchronizer.
+			"CREATE SEQUENCE quantumdb.synchronizer_columns_id;",
+			"CREATE TABLE quantumdb.synchronizer_columns (synchronizer_id BIGINT NOT NULL DEFAULT NEXTVAL('quantumdb.synchronizer_columns_id'), column_mapping_id BIGINT NOT NULL, PRIMARY KEY(synchronizer_id, column_mapping_id));",
+			"ALTER TABLE quantumdb.synchronizer_columns ADD CONSTRAINT synchronizer_columns_synchronizer_id FOREIGN KEY (synchronizer_id) REFERENCES quantumdb.synchronizers (id) ON DELETE CASCADE;",
+			"ALTER TABLE quantumdb.synchronizer_columns ADD CONSTRAINT synchronizer_columns_column_mapping_id FOREIGN KEY (column_mapping_id) REFERENCES quantumdb.column_mappings (id) ON DELETE CASCADE;",
 
-			// Creates the "quantumdb_active_versions" table which describes which versions are active at this time.
-			"CREATE TABLE quantumdb_active_versions (version_id VARCHAR(10), PRIMARY KEY (version_id));",
-			"ALTER TABLE quantumdb_active_versions ADD CONSTRAINT quantumdb_active_versions_version_id FOREIGN KEY (version_id) REFERENCES quantumdb_changelog (version_id) ON DELETE CASCADE;"
+			// Creates the "active_versions" table which describes which versions are active at this time.
+			"CREATE TABLE quantumdb.active_versions (version_id VARCHAR(10), PRIMARY KEY (version_id));",
+			"ALTER TABLE quantumdb.active_versions ADD CONSTRAINT active_versions_version_id FOREIGN KEY (version_id) REFERENCES quantumdb.changelog (version_id) ON DELETE CASCADE;"
 		);
 
 	public static int prepare(Connection connection) throws SQLException {
@@ -99,15 +99,20 @@ public class QuantumTables {
 		return version;
 	}
 
-	public static void dropEverything(Connection connection) throws SQLException {
+	public static void dropEverything(Connection connection, String... otherSchemasToDrop) throws SQLException {
 		connection.setAutoCommit(false);
 
+		List<String> schemasToDrop = Lists.newArrayList(otherSchemasToDrop);
+		schemasToDrop.add(0, "quantumdb");
+
 		try {
-			Statement statement = connection.createStatement();
-			statement.executeUpdate("DROP SCHEMA public CASCADE;");
-			statement.executeUpdate("CREATE SCHEMA public;");
-			statement.executeUpdate("ALTER SCHEMA public OWNER TO " + connection.getMetaData().getUserName() + ";");
-			statement.close();
+			for (String schema : schemasToDrop) {
+				Statement statement = connection.createStatement();
+				statement.executeUpdate("DROP SCHEMA " + schema + " CASCADE;");
+				statement.executeUpdate("CREATE SCHEMA " + schema + ";");
+				statement.executeUpdate("ALTER SCHEMA " + schema + " OWNER TO " + connection.getMetaData().getUserName() + ";");
+				statement.close();
+			}
 			connection.commit();
 		}
 		catch (SQLException e) {
@@ -117,7 +122,7 @@ public class QuantumTables {
 	}
 
 	private static void setVersion(Connection connection, int version) throws SQLException {
-		String query = "UPDATE quantumdb_config SET value = ? WHERE name = ?;";
+		String query = "UPDATE quantumdb.config SET value = ? WHERE name = ?;";
 		try (PreparedStatement statement = connection.prepareStatement(query)) {
 			statement.setString(1, Integer.toString(version));
 			statement.setString(2, VERSION_KEY);
@@ -127,7 +132,7 @@ public class QuantumTables {
 			}
 		}
 
-		query = "INSERT INTO quantumdb_config (name, value) VALUES (?, ?);";
+		query = "INSERT INTO quantumdb.config (name, value) VALUES (?, ?);";
 		try (PreparedStatement statement = connection.prepareStatement(query)) {
 			statement.setString(1, VERSION_KEY);
 			statement.setString(2, Integer.toString(version));
@@ -149,7 +154,11 @@ public class QuantumTables {
 	}
 
 	private static int getVersion(Connection connection) throws SQLException {
-		String query = "SELECT * FROM information_schema.tables WHERE table_name = 'quantumdb_config' AND table_schema = 'public';";
+		try (Statement statement = connection.createStatement()) {
+			statement.executeUpdate("CREATE SCHEMA IF NOT EXISTS quantumdb;");
+		}
+
+		String query = "SELECT * FROM information_schema.tables WHERE table_name = 'config' AND table_schema = 'quantumdb';";
 		try (Statement statement = connection.createStatement()) {
 			ResultSet resultSet = statement.executeQuery(query);
 			if (!resultSet.next()) {
@@ -157,7 +166,7 @@ public class QuantumTables {
 			}
 		}
 
-		query = "SELECT * FROM quantumdb_config WHERE name = ?;";
+		query = "SELECT * FROM quantumdb.config WHERE name = ?;";
 		try (PreparedStatement statement = connection.prepareStatement(query)) {
 			statement.setString(1, VERSION_KEY);
 			ResultSet resultSet = statement.executeQuery();

--- a/quantumdb-driver/src/main/java/io/quantumdb/driver/Transformer.java
+++ b/quantumdb-driver/src/main/java/io/quantumdb/driver/Transformer.java
@@ -21,7 +21,7 @@ class Transformer {
 		if (version != null && !version.isEmpty()) {
 			String query = new StringBuilder()
 					.append("SELECT table_id, table_name ")
-					.append("FROM quantumdb_table_versions ")
+					.append("FROM quantumdb.table_versions ")
 					.append("WHERE version_id = ?;")
 					.toString();
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
@@ -57,10 +57,6 @@ class CatalogLoader {
 			ResultSet resultSet = statement.executeQuery();
 			while (resultSet.next()) {
 				String tableName = resultSet.getString("table_name");
-				if (tableName.startsWith("quantumdb_")) {
-					// Skip quantumdb related tables, since these are versioned internally...
-					continue;
-				}
 				tableNames.add(tableName);
 			}
 		}

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlBackend.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlBackend.java
@@ -5,6 +5,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import io.quantumdb.core.backends.Config;
 import io.quantumdb.core.schema.definitions.Catalog;
@@ -86,7 +87,11 @@ public class PostgresqlBackend implements io.quantumdb.core.backends.Backend {
 	@SneakyThrows(ClassNotFoundException.class)
 	public Connection connect() throws SQLException {
 		Class.forName(driver);
-		return DriverManager.getConnection(jdbcUrl + "/" + jdbcCatalog, jdbcUser, jdbcPass);
+		Connection connection = DriverManager.getConnection(jdbcUrl + "/" + jdbcCatalog, jdbcUser, jdbcPass);
+		try (Statement statement = connection.createStatement()) {
+			statement.execute("SET SCHEMA 'public';");
+		}
+		return connection;
 	}
 
 }

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
@@ -25,6 +25,7 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import com.google.common.collect.Table.Cell;
 import com.google.common.primitives.Ints;
@@ -226,10 +227,10 @@ public class Backend {
 		Operations operations = new Operations();
 
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_changelog;";
-			String deleteQuery = "DELETE FROM quantumdb_changelog WHERE version_id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_changelog (version_id, operation_type, operation, parent_version_id) VALUES (?, ?, ?, ?);";
-			String updateQuery = "UPDATE quantumdb_changelog SET operation_type = ?, operation = ?, parent_version_id = ? WHERE version_id = ?;";
+			String query = "SELECT * FROM quantumdb.changelog;";
+			String deleteQuery = "DELETE FROM quantumdb.changelog WHERE version_id = ?;";
+			String insertQuery = "INSERT INTO quantumdb.changelog (version_id, operation_type, operation, parent_version_id) VALUES (?, ?, ?, ?);";
+			String updateQuery = "UPDATE quantumdb.changelog SET operation_type = ?, operation = ?, parent_version_id = ? WHERE version_id = ?;";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -328,10 +329,10 @@ public class Backend {
 		}
 
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_changesets;";
-			String deleteQuery = "DELETE FROM quantumdb_changesets WHERE version_id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_changesets (id, version_id, author, description, created) VALUES (?, ?, ?, ?, ?);";
-			String updateQuery = "UPDATE quantumdb_changesets SET author = ?, description = ?, created = ? WHERE version_id = ?;";
+			String query = "SELECT * FROM quantumdb.changesets;";
+			String deleteQuery = "DELETE FROM quantumdb.changesets WHERE version_id = ?;";
+			String insertQuery = "INSERT INTO quantumdb.changesets (id, version_id, author, description, created) VALUES (?, ?, ?, ?, ?);";
+			String updateQuery = "UPDATE quantumdb.changesets SET author = ?, description = ?, created = ? WHERE version_id = ?;";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -391,9 +392,9 @@ public class Backend {
 				.collect(Collectors.toSet());
 
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_tables ORDER BY table_id ASC;";
-			String deleteQuery = "DELETE FROM quantumdb_tables WHERE table_id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_tables (table_id) VALUES (?);";
+			String query = "SELECT * FROM quantumdb.tables ORDER BY table_id ASC;";
+			String deleteQuery = "DELETE FROM quantumdb.tables WHERE table_id = ?;";
+			String insertQuery = "INSERT INTO quantumdb.tables (table_id) VALUES (?);";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -451,9 +452,9 @@ public class Backend {
 		});
 
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_table_versions ORDER BY table_id ASC;";
-			String deleteQuery = "DELETE FROM quantumdb_table_versions WHERE table_id = ? AND version_id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_table_versions (table_id, version_id, table_name) VALUES (?, ?, ?);";
+			String query = "SELECT * FROM quantumdb.table_versions ORDER BY table_id ASC;";
+			String deleteQuery = "DELETE FROM quantumdb.table_versions WHERE table_id = ? AND version_id = ?;";
+			String insertQuery = "INSERT INTO quantumdb.table_versions (table_id, version_id, table_name) VALUES (?, ?, ?);";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -510,9 +511,9 @@ public class Backend {
 
 		List<RawTableColumn> columns = Lists.newArrayList();
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_table_columns ORDER BY id ASC;";
-			String deleteQuery = "DELETE FROM quantumdb_table_columns WHERE id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_table_columns (table_id, column_name) VALUES (?, ?) RETURNING id;";
+			String query = "SELECT * FROM quantumdb.table_columns ORDER BY id ASC;";
+			String deleteQuery = "DELETE FROM quantumdb.table_columns WHERE id = ?;";
+			String insertQuery = "INSERT INTO quantumdb.table_columns (table_id, column_name) VALUES (?, ?) RETURNING id;";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -592,9 +593,9 @@ public class Backend {
 
 		Map<Long, RawColumnMapping> results = Maps.newHashMap();
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_column_mappings;";
-			String deleteQuery = "DELETE FROM quantumdb_column_mappings WHERE id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_column_mappings (source_column_id, target_column_id) VALUES (?, ?) RETURNING id;";
+			String query = "SELECT * FROM quantumdb.column_mappings;";
+			String deleteQuery = "DELETE FROM quantumdb.column_mappings WHERE id = ?;";
+			String insertQuery = "INSERT INTO quantumdb.column_mappings (source_column_id, target_column_id) VALUES (?, ?) RETURNING id;";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -653,10 +654,10 @@ public class Backend {
 
 		Map<Long, SyncRef> mapping = Maps.newHashMap();
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_synchronizers;";
-			String deleteQuery = "DELETE FROM quantumdb_synchronizers WHERE id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_synchronizers (source_table_id, target_table_id, trigger_name, function_name) VALUES (?, ?, ?, ?) RETURNING id;";
-			String updateQuery = "UPDATE quantumdb_synchronizers SET trigger_name = ?, function_name = ? WHERE id = ?;";
+			String query = "SELECT * FROM quantumdb.synchronizers;";
+			String deleteQuery = "DELETE FROM quantumdb.synchronizers WHERE id = ?;";
+			String insertQuery = "INSERT INTO quantumdb.synchronizers (source_table_id, target_table_id, trigger_name, function_name) VALUES (?, ?, ?, ?) RETURNING id;";
+			String updateQuery = "UPDATE quantumdb.synchronizers SET trigger_name = ?, function_name = ? WHERE id = ?;";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -727,9 +728,9 @@ public class Backend {
 		});
 
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_synchronizer_columns;";
-			String deleteQuery = "DELETE FROM quantumdb_synchronizer_columns WHERE synchronizer_id = ? AND column_mapping = ?;";
-			String insertQuery = "INSERT INTO quantumdb_synchronizer_columns (synchronizer_id, column_mapping_id) VALUES (?, ?);";
+			String query = "SELECT * FROM quantumdb.synchronizer_columns;";
+			String deleteQuery = "DELETE FROM quantumdb.synchronizer_columns WHERE synchronizer_id = ? AND column_mapping = ?;";
+			String insertQuery = "INSERT INTO quantumdb.synchronizer_columns (synchronizer_id, column_mapping_id) VALUES (?, ?);";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -767,9 +768,9 @@ public class Backend {
 
 	private void persistActiveVersions(Connection connection, RefLog refLog) throws SQLException {
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_active_versions;";
-			String deleteQuery = "DELETE FROM quantumdb_active_versions WHERE version_id = ?;";
-			String insertQuery = "INSERT INTO quantumdb_active_versions (version_id) VALUES (?);";
+			String query = "SELECT * FROM quantumdb.active_versions;";
+			String deleteQuery = "DELETE FROM quantumdb.active_versions WHERE version_id = ?;";
+			String insertQuery = "INSERT INTO quantumdb.active_versions (version_id) VALUES (?);";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			Set<String> versions = refLog.getVersions().stream()
@@ -855,7 +856,7 @@ public class Backend {
 		RawChangelogEntry root = null;
 		Multimap<String, RawChangelogEntry> entries = HashMultimap.create();
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_changelog;";
+			String query = "SELECT * FROM quantumdb.changelog;";
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
 				String versionId = resultSet.getString("version_id");
@@ -897,7 +898,7 @@ public class Backend {
 
 		Map<String, RawChangeSet> changeSets = Maps.newHashMap();
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_changesets;";
+			String query = "SELECT * FROM quantumdb.changesets;";
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
 				String id = resultSet.getString("id");
@@ -926,7 +927,7 @@ public class Backend {
 	private Map<String, TableId> listTableIds(Connection connection) throws SQLException {
 		Map<String, TableId> tableIds = Maps.newHashMap();
 		try (Statement statement = connection.createStatement()) {
-			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb_tables ORDER BY table_id ASC;");
+			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb.tables ORDER BY table_id ASC;");
 			while (resultSet.next()) {
 				String tableId = resultSet.getString("table_id");
 				tableIds.put(tableId, new TableId(tableId));
@@ -938,7 +939,7 @@ public class Backend {
 	private Table<TableId, Version, String> listTableVersions(Connection connection, Map<String, TableId> tableIds, Changelog changelog) throws SQLException {
 		Table<TableId, Version, String> mapping = HashBasedTable.create();
 		try (Statement statement = connection.createStatement()) {
-			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb_table_versions ORDER BY table_id ASC;");
+			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb.table_versions ORDER BY table_id ASC;");
 			while (resultSet.next()) {
 				String tableId = resultSet.getString("table_id");
 				String tableName = resultSet.getString("table_name");
@@ -954,7 +955,7 @@ public class Backend {
 	private List<TableColumn> listTableColumns(Connection connection, Map<String, TableId> tableIds) throws SQLException {
 		List<TableColumn> results = Lists.newArrayList();
 		try (Statement statement = connection.createStatement()) {
-			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb_table_columns ORDER BY id ASC;");
+			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb.table_columns ORDER BY id ASC;");
 			while (resultSet.next()) {
 				long id = resultSet.getLong("id");
 				String tableId = resultSet.getString("table_id");
@@ -972,7 +973,7 @@ public class Backend {
 
 		List<TableColumnMapping> results = Lists.newArrayList();
 		try (Statement statement = connection.createStatement()) {
-			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb_column_mappings;");
+			ResultSet resultSet = statement.executeQuery("SELECT * FROM quantumdb.column_mappings;");
 			while (resultSet.next()) {
 				long id = resultSet.getLong("id");
 				long sourceColumnId = resultSet.getLong("source_column_id");
@@ -991,7 +992,7 @@ public class Backend {
 
 		Multimap<Long, Long> syncColumnMappings = HashMultimap.create();
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_synchronizer_columns;";
+			String query = "SELECT * FROM quantumdb.synchronizer_columns;";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -1002,7 +1003,7 @@ public class Backend {
 		}
 
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_synchronizers;";
+			String query = "SELECT * FROM quantumdb.synchronizers;";
 
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
@@ -1043,13 +1044,29 @@ public class Backend {
 
 	private void setActiveVersions(Connection connection, Changelog changelog, RefLog refLog) throws SQLException {
 		try (Statement statement = connection.createStatement()) {
-			String query = "SELECT * FROM quantumdb_active_versions;";
+			String query = "SELECT * FROM quantumdb.active_versions;";
 
+			Set<String> activeVersions = Sets.newHashSet();
 			ResultSet resultSet = statement.executeQuery(query);
 			while (resultSet.next()) {
 				String versionId = resultSet.getString("version_id");
-				Version version = changelog.getVersion(versionId);
-				refLog.setVersionState(version, true);
+				activeVersions.add(versionId);
+			}
+
+			Version pointer = changelog.getRoot();
+			while (pointer != null) {
+				String versionId = pointer.getId();
+				if (activeVersions.contains(versionId)) {
+					activeVersions.remove(versionId);
+					Version version = changelog.getVersion(versionId);
+					refLog.setVersionState(version, true);
+				}
+				pointer = pointer.getChild();
+			}
+
+			if (!activeVersions.isEmpty()) {
+				throw new IllegalStateException("There's are active versions defined which are not present or " +
+						"reachable in the changelog: " + activeVersions.stream().collect(Collectors.joining(",")));
 			}
 		}
 


### PR DESCRIPTION
Previously we "littered" the public schema with all these meta tables to store state information in. However, it's not very neat, so this PR "hides" them in a separate schema.