### PR TITLE
Improve the way we use the CLI

### DIFF
--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Drop.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Drop.java
@@ -32,7 +32,8 @@ public class Drop extends Command {
 			State state = loadState(backend);
 			Changelog changelog = state.getChangelog();
 
-			Version version = changelog.getVersion(arguments.remove(0));
+			String versionId = arguments.remove(0);
+			Version version = changelog.getVersion(versionId);
 
 			writer.write("Checking how many clients are still connected to: " + version.getId());
 			int count = backend.countClientsConnectedToVersion(version);

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Fork.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Fork.java
@@ -33,8 +33,8 @@ public class Fork extends Command {
 			State state = loadState(backend);
 			Changelog changelog = state.getChangelog();
 
-			Version to = changelog.getVersion(arguments.remove(0));
 			Version from = getOriginVersion(arguments, state, changelog);
+			Version to = changelog.getVersion(arguments.remove(0));
 
 			writer.write("Forking database from: " + from.getId() + " to: " + to.getId() + "...");
 
@@ -50,19 +50,20 @@ public class Fork extends Command {
 		}
 	}
 
-	private Version getOriginVersion(List<String> arguments, State state, Changelog changelog) throws CliException {
-		if (arguments.isEmpty()) {
+	private Version getOriginVersion(List<String> arguments, State state, Changelog changelog) {
+		String versionId = getArgument(arguments, "from", String.class, () -> {
 			List<Version> versions = Lists.newArrayList(state.getRefLog().getVersions());
 			if (versions.isEmpty()) {
 				versions.add(changelog.getRoot());
 			}
 
 			if (versions.size() == 1) {
-				return versions.get(0);
+				return versions.get(0).getId();
 			}
 			throw new CliException("You must specify a version to fork from!");
-		}
-		return changelog.getVersion(arguments.remove(0));
+		});
+
+		return changelog.getVersion(versionId);
 	}
 
 }

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Init.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Init.java
@@ -26,18 +26,14 @@ public class Init extends Command {
 
 	public void perform(CliWriter writer, List<String> arguments) {
 		try {
-			Config config;
-			if (arguments.isEmpty()) {
-				config = Config.load();
-			}
-			else {
-				String url = arguments.isEmpty() ? "" : arguments.remove(0);
-				String catalogName = arguments.isEmpty() ? "" : arguments.remove(0);
-				String user = arguments.isEmpty() ? "" : arguments.remove(0);
-				String pass = arguments.isEmpty() ? "" : arguments.remove(0);
+			Config config = Config.load();
+			if (!arguments.isEmpty()) {
+				String hosts = getArgument(arguments, "host", String.class, () -> "localhost:5432");
+				String catalogName = getArgument(arguments, "database", String.class);
+				String user = getArgument(arguments, "username", String.class);
+				String pass = getArgument(arguments, "password", String.class, null);
 
-				config = new Config();
-				config.setUrl(url);
+				config.setUrl("jdbc:postgresql://" + hosts + "/" + catalogName + "?targetServerType=master\"");
 				config.setCatalog(catalogName);
 				config.setUser(user);
 				config.setPassword(pass);
@@ -75,7 +71,7 @@ public class Init extends Command {
 		}
 	}
 
-	private String getDatabaseVendor(Backend backend) throws CliException {
+	private String getDatabaseVendor(Backend backend) {
 		try (Connection connection = backend.connect()) {
 			DatabaseMetaData metaData = connection.getMetaData();
 			return metaData.getDatabaseProductName() + " " + metaData.getDatabaseProductVersion();

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
@@ -1,21 +1,36 @@
 package io.quantumdb.cli.commands;
 
-import java.io.IOException;
+import static java.sql.ResultSet.CONCUR_READ_ONLY;
+import static java.sql.ResultSet.TYPE_SCROLL_INSENSITIVE;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.ResultSetMetaData;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.quantumdb.cli.utils.CliException;
 import io.quantumdb.cli.utils.CliWriter;
 import io.quantumdb.cli.utils.CliWriter.Context;
 import io.quantumdb.core.backends.Config;
+import io.quantumdb.core.versioning.State;
+import io.quantumdb.core.versioning.Version;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class Query extends Command {
+
+	private interface ConnectionConsumer {
+		void consume(Connection connection) throws Throwable;
+	}
 
 	@Override
 	public Identifier getIdentifier() {
@@ -25,50 +40,169 @@ public class Query extends Command {
 	public void perform(CliWriter writer, List<String> arguments) {
 		try {
 			Config config = Config.load();
-			String versionId = arguments.remove(0);
+			Version version = getVersionId(arguments, config);
 			String query = arguments.stream()
 					.collect(Collectors.joining(" "));
 
 			Class.forName("io.quantumdb.driver.Driver");
-			String url = createUrl(config.getUrl(), config.getCatalog(), versionId);
-			try (Connection connection = DriverManager.getConnection(url, config.getUser(), config.getPassword())) {
-				Statement statement = connection.createStatement();
 
-				if (query.toLowerCase().trim().startsWith("select")) {
-					ResultSet resultSet = statement.executeQuery(query);
-
-					boolean results = false;
-					while (resultSet.next()) {
-						results = true;
-						System.out.println("{");
-						for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); i++) {
-							String columnName = resultSet.getMetaData().getColumnName(i);
-							Object value = resultSet.getObject(columnName);
-							String terminus = (i < resultSet.getMetaData().getColumnCount()) ? "," : "";
-							System.out.println("\t" + columnName + ": " + value + terminus);
-						}
-						System.out.println("}");
-					}
-
-
-					if (!results) {
-						writer.write("No results found!");
-					}
-				}
-				else {
-					int affected = statement.executeUpdate(query);
-					writer.write("Affected rows: " + affected);
-				}
+			try {
+				executeAndParseResultSet(writer, config, version, query);
+			}
+			catch (Throwable e) {
+				executeUpdate(writer, config, version, query);
 			}
 		}
-		catch (ClassNotFoundException | SQLException | IOException e) {
+		catch (Throwable e) {
 			log.error(e.getMessage(), e);
 			writer.write(e.getMessage(), Context.FAILURE);
 		}
 	}
 
+	private void executeUpdate(CliWriter writer, Config config, Version version, String query) throws Throwable {
+		doInTransaction(config, version, connection -> {
+			Statement statement = connection.createStatement();
+			int affected = statement.executeUpdate(query);
+			writer.write("Affected rows: " + affected);
+		});
+	}
+
+	private void executeAndParseResultSet(CliWriter writer, Config config, Version version, String query) throws Throwable {
+		doInTransaction(config, version, connection -> {
+			Statement statement = connection.createStatement(TYPE_SCROLL_INSENSITIVE, CONCUR_READ_ONLY);
+			ResultSet resultSet = statement.executeQuery(query);
+
+			Map<String, Boolean> padLeft = Maps.newHashMap();
+			List<String> columnNames = Lists.newArrayList();
+			ResultSetMetaData metaData = resultSet.getMetaData();
+
+			for (int i = 1; i <= metaData.getColumnCount(); i++) {
+				String columnName = metaData.getColumnName(i);
+				Class<?> type = Class.forName(metaData.getColumnClassName(i));
+				padLeft.put(columnName, Number.class.isAssignableFrom(type));
+				columnNames.add(columnName);
+			}
+
+			Map<String, Integer> columnWidths = Maps.newLinkedHashMap();
+			for (String columnName : columnNames) {
+				columnWidths.put(columnName, columnName.length());
+			}
+
+			long results = 0;
+			while (resultSet.next()) {
+				results++;
+				for (String columnName : columnNames) {
+					Integer width = columnWidths.getOrDefault(columnName, 0);
+					Object object = resultSet.getObject(columnName);
+					String value = object == null ? "" : Objects.toString(object);
+					int currentLength = value.length();
+					if (width < currentLength) {
+						columnWidths.put(columnName, currentLength);
+					}
+				}
+			}
+
+			if (results > 0) {
+				StringBuilder builder = new StringBuilder();
+				for (int i = 0; i < columnNames.size(); i++) {
+					String columnName = columnNames.get(i);
+					if (i > 0) {
+						builder.append("|");
+					}
+					builder.append(" ");
+
+					int width = columnWidths.get(columnName);
+					if (padLeft.get(columnName)) {
+						builder.append(Strings.padStart(columnName, width, ' '));
+					}
+					else {
+						builder.append(Strings.padEnd(columnName, width, ' '));
+					}
+					builder.append(" ");
+				}
+
+				int length = builder.length();
+				builder.append("\n")
+						.append(Strings.repeat("-", length))
+						.append("\n");
+
+				resultSet.beforeFirst();
+				while (resultSet.next()) {
+					for (int i = 0; i < columnNames.size(); i++) {
+						String columnName = columnNames.get(i);
+						if (i > 0) {
+							builder.append("|");
+						}
+						builder.append(" ");
+
+						int columnWidth = columnWidths.get(columnName);
+						Object object = resultSet.getObject(columnName);
+						String value = object == null ? "" : Objects.toString(object);
+						if (padLeft.get(columnName)) {
+							builder.append(Strings.padStart(value, columnWidth, ' '));
+						}
+						else {
+							builder.append(Strings.padEnd(value, columnWidth, ' '));
+						}
+
+						builder.append(" ");
+					}
+					builder.append("\n");
+				}
+				builder.append("(")
+						.append(results)
+						.append(" rows)\n");
+
+				writer.indent(-1)
+						.enableBold(false)
+						.write(builder.toString())
+						.enableBold(true);
+			}
+			else {
+				writer.indent(-1)
+						.enableBold(false)
+						.write("--\n(0 rows)\n")
+						.enableBold(true);
+			}
+		});
+	}
+
+	private void doInTransaction(Config config, Version version, ConnectionConsumer consumer) throws Throwable {
+		String url = createUrl(config.getUrl(), config.getCatalog(), version.getId());
+		try (Connection connection = DriverManager.getConnection(url, config.getUser(), config.getPassword())) {
+			connection.setAutoCommit(false);
+			try {
+				consumer.consume(connection);
+				connection.commit();
+			}
+			catch (Throwable e) {
+				connection.rollback();
+				throw e;
+			}
+		}
+	}
+
 	private String createUrl(String url, String catalog, String versionId) {
 		return url.replace("jdbc:", "jdbc:quantumdb:") + "/" + catalog + "?version=" + versionId;
+	}
+
+	private Version getVersionId(List<String> arguments, Config config) {
+		State state = loadState(config.getBackend());
+		String versionId = getArgument(arguments, "version", String.class, () -> {
+			List<Version> versions = Lists.newArrayList(state.getRefLog().getVersions());
+			if (versions.isEmpty()) {
+				versions.add(state.getChangelog().getRoot());
+			}
+
+			if (versions.size() == 1) {
+				return versions.get(0).getId();
+			}
+			throw new CliException("You must specify a version to query!");
+		});
+
+		return Optional.ofNullable(versionId)
+				.map(state.getChangelog()::getVersion)
+				.orElseThrow(() -> new CliException("You must specify a (valid) version to query"));
 	}
 
 }

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/utils/CliException.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/utils/CliException.java
@@ -1,6 +1,6 @@
 package io.quantumdb.cli.utils;
 
-public class CliException extends Exception {
+public class CliException extends RuntimeException {
 
 	public CliException(String message) {
 		super(message);

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/utils/CliWriter.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/utils/CliWriter.java
@@ -18,6 +18,8 @@ public class CliWriter {
 
 	private final Terminal terminal;
 	private final ConsoleReader reader;
+
+	private boolean enableBold = true;
 	private int indent = 0;
 
 	public CliWriter() {
@@ -34,6 +36,11 @@ public class CliWriter {
 
 	public void close() {
 		Terminal.resetTerminal();
+	}
+
+	public CliWriter enableBold(boolean enableBold) {
+		this.enableBold = enableBold;
+		return this;
 	}
 
 	public CliWriter indent(int delta) {
@@ -70,7 +77,14 @@ public class CliWriter {
 			message = Strings.repeat("  ", indent) + marker + message;
 		}
 		if (indent <= 0) {
-			message = new ANSIBuffer().bold(message).toString();
+			ANSIBuffer buffer = new ANSIBuffer();
+			if (enableBold) {
+				buffer.bold(message);
+			}
+			else {
+				buffer.append(message);
+			}
+			message = buffer.toString();
 		}
 
 		switch (context) {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/RefLog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/RefLog.java
@@ -376,7 +376,7 @@ public class RefLog {
 	 */
 	public RefLog() {
 		this.tables = LinkedHashMultimap.create();
-		this.activeVersions = Sets.newHashSet();
+		this.activeVersions = Sets.newLinkedHashSet();
 	}
 
 	/**

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
@@ -49,6 +49,7 @@ public class PostgresTypes {
 				return PostgresTypes.text();
 			case "timestamp with time zone":
 				return PostgresTypes.timestamp(true);
+			case "timestamp":
 			case "timestamp without time zone":
 				return PostgresTypes.timestamp(false);
 			case "date":


### PR DESCRIPTION
The CLI was a bit clumsy to use. This PR addresses a couple of things:

- Optional arguments for commands can now be set using `--key=value` arguments.
- Changelog command has a couple new arguments to better navigate big changelogs, and has improved descriptions.
- Fork command has an optional argument to specify the "from" version.
- Init command now utilises only optional arguments.
- Nuke command now returns some textual confirmation.