### PR TITLE
Various fixes and redesigned logic

### DIFF
--- a/docs/docs/master/index.html
+++ b/docs/docs/master/index.html
@@ -176,7 +176,7 @@ changelog.addChangeSet("track_users", "Michael de Jong",
                 This code will create a new <code>admin</code> column in the <code>users</code> table, of type
                 <code>boolean</code>, which defaults to the <code>false</code> value, and cannot hold <code>NULL</code>
                 values. It's not required to set a default value. You can specify zero, one, or multiple hints of the
-                following types <code>AUTO_INCREMENT</code>, <code>NOT_NULL</code>, <code>IDENTITY</code>.
+                following types <code>AUTO_INCREMENT</code>, <code>NOT_NULL</code>, <code>PRIMARY_KEY</code> and <code>UNIQUE</code>.
             </p>
 
             <h3>ADD FOREIGN KEY</h3>
@@ -257,11 +257,21 @@ changelog.addChangeSet("track_users", "Michael de Jong",
   &lt;column name="id" type="bigint" primaryKey="true" autoIncrement="true" /&gt;
   &lt;column name="first_name" type="text" nullable="false" /&gt;
   &lt;column name="last_name" type="text" nullable="false" /&gt;
+  &lt;column name="username" type="text" nullable="false" unique="true" /&gt;
+  &lt;column name="postal_code" type="text" nullable="false" unique="address" /&gt;
+  &lt;column name="house_number" type="integer" nullable="false" unique="address" /&gt;
+
 &lt;/createTable&gt;</code></pre>
 
             <p>
                 This example will create a new <code>users</code> table with three columns <code>id</code>,
                 <code>first_name</code>, and <code>last_name</code>.
+            </p>
+            <p>
+                The <code>unique</code> constraint works a little different than the other constraints as multiple columns
+                can be unique together. If you want a column to be unique by it self just set the unique
+                attribute to <code>true</code>. However, if you want multiple columns to be unique specify a name that is not
+                <code>true</code> or <code>false</code> and apply it to all columns. For an example look at the above code.
             </p>
 
             <h3>DROP COLUMN</h3>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>io.quantumdb</groupId>
 	<artifactId>quantumdb</artifactId>
 	<packaging>pom</packaging>
-	<version>0.4.1-SNAPSHOT</version>
+	<version>0.4.2-SNAPSHOT</version>
 
 	<modules>
 		<module>quantumdb-core</module>
@@ -32,46 +32,46 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.4</version>
+			<version>1.18.20</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>17.0</version>
+			<version>30.1.1-jre</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
 		</dependency>
-
 		<!-- Logging -->
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.1.2</version>
+			<version>1.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
-			<version>1.7.6</version>
+			<version>1.7.30</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jul-to-slf4j</artifactId>
-			<version>1.7.6</version>
+			<version>1.7.30</version>
 		</dependency>
 
 		<!-- Testing -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.9.5</version>
+			<version>3.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/quantumdb-cli/pom.xml
+++ b/quantumdb-cli/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<artifactId>quantumdb</artifactId>
 		<groupId>io.quantumdb</groupId>
-		<version>0.4.1-SNAPSHOT</version>
+		<version>0.4.2-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>quantumdb-cli</artifactId>
-	<version>0.4.1-SNAPSHOT</version>
+	<version>0.4.2-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>
@@ -28,15 +28,17 @@
 			<artifactId>quantumdb-driver</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/jline/jline -->
 		<dependency>
 			<groupId>jline</groupId>
 			<artifactId>jline</artifactId>
 			<version>0.9.94</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-xml -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-xml</artifactId>
-			<version>2.9.5</version>
+			<version>2.12.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.woodstox</groupId>
@@ -50,7 +52,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.3.0</version>
 				<configuration>
 					<archive>
 						<manifest>

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
@@ -41,6 +41,7 @@ public class Main {
 			String command = arguments.remove(0);
 			Command delegate = commands.get(command);
 			if (delegate != null) {
+				writer.write("Executing command: " + command + " with arguments: " + arguments);
 				delegate.perform(writer, arguments);
 			}
 			else {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class Main {
 
 	public static void main(String[] args) throws IOException, SQLException {
-		log.info("Parsing command: {}", Stream.of(args).collect(Collectors.joining(" ")));
+		log.info("Parsing command: {}", String.join(" ", args));
 
 		CliWriter writer = new CliWriter();
 		List<String> arguments = normalize(args);
@@ -41,7 +41,6 @@ public class Main {
 			String command = arguments.remove(0);
 			Command delegate = commands.get(command);
 			if (delegate != null) {
-				writer.write("Executing command: " + command + " with arguments: " + arguments);
 				delegate.perform(writer, arguments);
 			}
 			else {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Init.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Init.java
@@ -33,7 +33,7 @@ public class Init extends Command {
 				String user = getArgument(arguments, "username", String.class);
 				String pass = getArgument(arguments, "password", String.class, null);
 
-				config.setUrl("jdbc:postgresql://" + hosts); // Postgresql driver 9.3 vs 42: + "/" + catalogName + "?targetServerType=master\""
+				config.setUrl("jdbc:postgresql://" + hosts);
 				config.setCatalog(catalogName);
 				config.setUser(user);
 				config.setPassword(pass);

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Init.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Init.java
@@ -33,7 +33,7 @@ public class Init extends Command {
 				String user = getArgument(arguments, "username", String.class);
 				String pass = getArgument(arguments, "password", String.class, null);
 
-				config.setUrl("jdbc:postgresql://" + hosts + "/" + catalogName + "?targetServerType=master\"");
+				config.setUrl("jdbc:postgresql://" + hosts); // Postgresql driver 9.3 vs 42: + "/" + catalogName + "?targetServerType=master\""
 				config.setCatalog(catalogName);
 				config.setUser(user);
 				config.setPassword(pass);

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
@@ -49,10 +49,13 @@ public class XmlAddColumn implements XmlOperation<AddColumn> {
 			hints.add(Hint.AUTO_INCREMENT);
 		}
 		if (column.isPrimaryKey()) {
-			hints.add(Hint.IDENTITY);
+			hints.add(Hint.PRIMARY_KEY);
+		}
+		if (column.isUnique()) {
+			hints.add(Hint.UNIQUE);
 		}
 
-		Hint[] hintArray = hints.toArray(new Hint[hints.size()]);
+		Hint[] hintArray = hints.toArray(new Hint[0]);
 		return SchemaOperations.addColumn(tableName, columnName, dataType, defaultExpression, hintArray);
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
@@ -42,7 +42,7 @@ public class XmlAddColumn implements XmlOperation<AddColumn> {
 		String defaultExpression = column.getDefaultExpression();
 
 		List<Hint> hints = Lists.newArrayList();
-		if (column.isNullable()) {
+		if (!column.isNullable()) {
 			hints.add(Hint.NOT_NULL);
 		}
 		if (column.isAutoIncrement()) {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterColumn.java
@@ -34,6 +34,18 @@ public class XmlAlterColumn implements XmlOperation<AlterColumn> {
 				.map(Boolean.TRUE.toString()::equals)
 				.ifPresent(operation::setNullable);
 
+		Optional.ofNullable(attributes.get("unique"))
+				.map(Boolean.TRUE.toString()::equals)
+				.ifPresent(operation::setUnique);
+
+		Optional.ofNullable(attributes.get("primaryKey"))
+				.map(Boolean.TRUE.toString()::equals)
+				.ifPresent(operation::setPrimaryKey);
+
+		Optional.ofNullable(attributes.get("autoIncrementing"))
+				.map(Boolean.TRUE.toString()::equals)
+				.ifPresent(operation::setAutoIncrementing);
+
 		return operation;
 	}
 
@@ -43,6 +55,9 @@ public class XmlAlterColumn implements XmlOperation<AlterColumn> {
 	private String newColumnName;
 	private String newType;
 	private Boolean nullable;
+	private Boolean unique;
+	private Boolean primaryKey;
+	private Boolean autoIncrementing;
 
 	@Override
 	public AlterColumn toOperation() {
@@ -59,7 +74,34 @@ public class XmlAlterColumn implements XmlOperation<AlterColumn> {
 			}
 		});
 
-		// TODO: Support other hints?
+		// TODO: NOT REALLY TESTED!
+
+		Optional.ofNullable(unique).ifPresent(newUnique -> {
+			if (newUnique) {
+				operation.addHint(Hint.UNIQUE);
+			}
+			else {
+				operation.dropHint(Hint.UNIQUE);
+			}
+		});
+
+		Optional.ofNullable(primaryKey).ifPresent(newPrimarykey -> {
+			if (newPrimarykey) {
+				operation.addHint(Hint.PRIMARY_KEY);
+			}
+			else {
+				operation.dropHint(Hint.PRIMARY_KEY);
+			}
+		});
+
+		Optional.ofNullable(autoIncrementing).ifPresent(newAutoIncrementing -> {
+			if (newAutoIncrementing) {
+				operation.addHint(Hint.AUTO_INCREMENT);
+			}
+			else {
+				operation.dropHint(Hint.AUTO_INCREMENT);
+			}
+		});
 
 		return operation;
 	}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlColumn.java
@@ -16,15 +16,29 @@ public class XmlColumn {
 		column.setDefaultExpression(element.getAttributes().get("defaultExpression"));
 		column.setPrimaryKey(Boolean.TRUE.toString().equals(element.getAttributes().get("primaryKey")));
 		column.setAutoIncrement(Boolean.TRUE.toString().equals(element.getAttributes().get("autoIncrement")));
-		column.setNullable(Boolean.TRUE.toString().equals(element.getAttributes().get("nullable")));
+		column.setNullable(!Boolean.FALSE.toString().equals(element.getAttributes().get("nullable")));
+		if (element.getAttributes().get("unique") != null) {
+			column.setUnique(!Boolean.FALSE.toString().equals(element.getAttributes().get("unique")));
+			if (column.isUnique() && !Boolean.TRUE.toString().equals(element.getAttributes().get("unique"))) {
+				// If unique is not true or false, set composite unique
+				column.setCompositeUnique(element.getAttributes().get("unique"));
+			} else {
+				column.setCompositeUnique(null);
+			}
+		} else {
+			column.setUnique(false);
+			column.setCompositeUnique(null);
+		}
 		return column;
 	}
 
 	private String name;
 	private String type;
 	private String defaultExpression;
+	private String compositeUnique;
 	private boolean primaryKey;
 	private boolean autoIncrement;
+	private boolean unique;
 	private boolean nullable;
 
 }

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
@@ -2,12 +2,14 @@ package io.quantumdb.cli.xml;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.HashMap;
 import java.util.List;
 
 import com.google.common.collect.Lists;
 import io.quantumdb.core.schema.definitions.Column.Hint;
 import io.quantumdb.core.schema.definitions.ColumnType;
 import io.quantumdb.core.schema.definitions.PostgresTypes;
+import io.quantumdb.core.schema.definitions.Unique;
 import io.quantumdb.core.schema.operations.CreateTable;
 import io.quantumdb.core.schema.operations.SchemaOperations;
 import lombok.Data;
@@ -40,6 +42,7 @@ public class XmlCreateTable implements XmlOperation<CreateTable> {
 	@Override
 	public CreateTable toOperation() {
 		CreateTable operation = SchemaOperations.createTable(tableName);
+		HashMap<String, List<String>> uniques = new HashMap<>();
 		for (XmlColumn column : columns) {
 			ColumnType type = PostgresTypes.from(column.getType());
 			String defaultExpression = column.getDefaultExpression();
@@ -54,10 +57,28 @@ public class XmlCreateTable implements XmlOperation<CreateTable> {
 			if (!column.isNullable()) {
 				hints.add(Hint.NOT_NULL);
 			}
+			if (column.isUnique()) {
+				hints.add(Hint.UNIQUE);
+				// If part of existing Unique object add it, otherwise create new Unique object
+				if (column.getCompositeUnique() != null) {
+					if (uniques.containsKey(column.getCompositeUnique())) {
+						uniques.get(column.getCompositeUnique()).add(column.getName());
+					} else {
+						uniques.put(column.getCompositeUnique(), Lists.newArrayList(column.getName()));
+					}
+				} else {
+					uniques.put(column.getName(), Lists.newArrayList(column.getName()));
+				}
+			}
 
 			Hint[] hintArray = hints.toArray(new Hint[0]);
 			operation.with(column.getName(), type, defaultExpression, hintArray);
 		}
+		for (String key: uniques.keySet()) {
+			Unique unique = new Unique(uniques.get(key));
+			operation.withUnique(unique);
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
@@ -26,7 +26,9 @@ public class XmlCreateTable implements XmlOperation<CreateTable> {
 		operation.setTableName(element.getAttributes().get("tableName"));
 
 		for (XmlElement child : element.getChildren()) {
-			if (child.getTag().equals("columns")) {
+			if (child.getTag().equals("column")) {
+				operation.getColumns().add(XmlColumn.convert(child));
+			} else if (child.getTag().equals("columns")) {
 				for (XmlElement subChild : child.getChildren()) {
 					operation.getColumns().add(XmlColumn.convert(subChild));
 				}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
@@ -46,7 +46,7 @@ public class XmlCreateTable implements XmlOperation<CreateTable> {
 
 			List<Hint> hints = Lists.newArrayList();
 			if (column.isPrimaryKey()) {
-				hints.add(Hint.IDENTITY);
+				hints.add(Hint.PRIMARY_KEY);
 			}
 			if (column.isAutoIncrement()) {
 				hints.add(Hint.AUTO_INCREMENT);
@@ -55,7 +55,7 @@ public class XmlCreateTable implements XmlOperation<CreateTable> {
 				hints.add(Hint.NOT_NULL);
 			}
 
-			Hint[] hintArray = hints.toArray(new Hint[hints.size()]);
+			Hint[] hintArray = hints.toArray(new Hint[0]);
 			operation.with(column.getName(), type, defaultExpression, hintArray);
 		}
 		return operation;

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlMapper.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlMapper.java
@@ -22,6 +22,12 @@ public class XmlMapper {
 		return XmlChangelog.convert(element);
 	}
 
+	/**
+	 * Parses the current XML file into XmlElements and gives back the root XmlElement
+	 * @param file the file the parser should load
+	 * @return root XmlElement of XML file
+	 * @throws IOException when XML file is not correct
+	 */
 	private XmlElement load(String file) throws IOException {
 		try {
 			SAXParserFactory factory = SAXParserFactory.newInstance();
@@ -65,7 +71,7 @@ public class XmlMapper {
 				}
 
 				@SneakyThrows
-				public void characters(char ch[], int start, int length) {
+				public void characters(char[] ch, int start, int length) {
 					String body = new String(ch, start, length);
 					if (body.trim().isEmpty()) {
 						return;

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlMapper.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlMapper.java
@@ -42,6 +42,19 @@ public class XmlMapper {
 					for (int i = 0; i < attributes.getLength(); i++) {
 						String key = attributes.getQName(i);
 						String value = attributes.getValue(i);
+						// Convert all values to lowercase except when quoted
+						// PostgreSQL converts table and column names to lowercase while Oracle converts them to uppercase
+						// XML double quote escapement is &quot;
+						char[] chars = value.toCharArray();
+						boolean insideQuotes = false;
+						for (int j = 0; j < chars.length; j++) {
+							if (chars[j] == '"') {
+								insideQuotes = !insideQuotes;
+							} else if (!insideQuotes) {
+								chars[j] = Character.toLowerCase(chars[j]);
+							}
+						}
+						value = String.valueOf(chars);
 						element.getAttributes().put(key, value);
 					}
 

--- a/quantumdb-core/pom.xml
+++ b/quantumdb-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>io.quantumdb</groupId>
 		<artifactId>quantumdb</artifactId>
-		<version>0.4.1-SNAPSHOT</version>
+		<version>0.4.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>quantumdb-core</artifactId>
@@ -27,24 +27,25 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.3-1101-jdbc41</version>
+			<version>42.2.20</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.3</version>
+			<version>2.8.6</version>
 		</dependency>
-	</dependencies>
+    </dependencies>
 
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.3.0</version>
 				<configuration>
 					<archive>
 						<manifest>

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/Config.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/Config.java
@@ -10,6 +10,8 @@ import java.util.Properties;
 import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Slf4j
 public class Config {
 
@@ -96,25 +98,23 @@ public class Config {
 
 	public Backend getBackend() {
 		String jdbcUrl = getUrl();
-		if (jdbcUrl != null) {
-			for (String backendName : SUPPORTED_BACKENDS) {
-				try {
-					Class<?> type = Class.forName(backendName);
-					Backend backend = (Backend) type.getDeclaredConstructor(Config.class).newInstance(this);
-					if (backend.isJdbcUrlSupported(jdbcUrl)) {
-						return backend;
-					}
-				}
-				catch (ReflectiveOperationException e) {
-					throw new IllegalArgumentException("Something went wrong selecting backends.");
-					// Skip this one.
+		checkArgument(jdbcUrl != null, "You have not specified a backend URL.");
+
+		for (String backendName : SUPPORTED_BACKENDS) {
+			try {
+				Class<?> type = Class.forName(backendName);
+				Backend backend = (Backend) type.getDeclaredConstructor(Config.class).newInstance(this);
+				if (backend.isJdbcUrlSupported(jdbcUrl)) {
+					return backend;
 				}
 			}
-
-			throw new IllegalArgumentException("No backend support for JDBC URL: " + jdbcUrl);
-		} else {
-			throw new IllegalArgumentException("You have not specified a backend URL");
+			catch (ReflectiveOperationException e) {
+				throw new IllegalArgumentException("Something went wrong selecting backends.");
+				// Skip this one.
+			}
 		}
+
+		throw new IllegalArgumentException("No backend support for JDBC URL: " + jdbcUrl);
 
 	}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/Config.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/Config.java
@@ -96,21 +96,26 @@ public class Config {
 
 	public Backend getBackend() {
 		String jdbcUrl = getUrl();
-
-		for (String backendName : SUPPORTED_BACKENDS) {
-			try {
-				Class<?> type = Class.forName(backendName);
-				Backend backend = (Backend) type.getDeclaredConstructor(Config.class).newInstance(this);
-				if (backend.isJdbcUrlSupported(jdbcUrl)) {
-					return backend;
+		if (jdbcUrl != null) {
+			for (String backendName : SUPPORTED_BACKENDS) {
+				try {
+					Class<?> type = Class.forName(backendName);
+					Backend backend = (Backend) type.getDeclaredConstructor(Config.class).newInstance(this);
+					if (backend.isJdbcUrlSupported(jdbcUrl)) {
+						return backend;
+					}
+				}
+				catch (ReflectiveOperationException e) {
+					throw new IllegalArgumentException("Something went wrong selecting backends.");
+					// Skip this one.
 				}
 			}
-			catch (ReflectiveOperationException e) {
-				// Skip this one.
-			}
+
+			throw new IllegalArgumentException("No backend support for JDBC URL: " + jdbcUrl);
+		} else {
+			throw new IllegalArgumentException("You have not specified a backend URL");
 		}
 
-		throw new IllegalArgumentException("No backend support for JDBC URL: " + jdbcUrl);
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/planner/Operation.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/planner/Operation.java
@@ -8,8 +8,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.quantumdb.core.schema.definitions.Table;
 import lombok.Data;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Data
 public class Operation {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/planner/PlanValidator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/planner/PlanValidator.java
@@ -103,7 +103,7 @@ public class PlanValidator {
 
 			Table table = operation.getTables().iterator().next();
 
-			List<Column> identityColumns = table.getIdentityColumns();
+			List<Column> identityColumns = table.getPrimaryKeyColumns();
 			Set<Column> columns = operation.getColumns().stream()
 					.map(table::getColumn)
 					.collect(Collectors.toSet());

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/planner/Step.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/planner/Step.java
@@ -13,8 +13,8 @@ import io.quantumdb.core.backends.planner.Operation.Type;
 import io.quantumdb.core.schema.definitions.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Getter(AccessLevel.NONE)
 public class Step {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
@@ -64,7 +64,6 @@ public class Migrator {
 	public void migrate(String sourceVersionId, String targetVersionId) throws MigrationException {
 		log.info("Forking from version: {} to version: {}", sourceVersionId, targetVersionId);
 
-		// ToDo give state as parameter as it is already loaded before
 		State state = loadState();
 		Changelog changelog = state.getChangelog();
 		Version from = changelog.getVersion(sourceVersionId);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
@@ -64,6 +64,7 @@ public class Migrator {
 	public void migrate(String sourceVersionId, String targetVersionId) throws MigrationException {
 		log.info("Forking from version: {} to version: {}", sourceVersionId, targetVersionId);
 
+		// ToDo give state as parameter as it is already loaded before
 		State state = loadState();
 		Changelog changelog = state.getChangelog();
 		Version from = changelog.getVersion(sourceVersionId);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CopyTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CopyTableMigrator.java
@@ -26,8 +26,7 @@ class CopyTableMigrator implements SchemaOperationMigrator<CopyTable> {
 
 		refLog.fork(version);
 		TableRef sourceTableRef = refLog.getTableRef(version.getParent(), sourceTableName);
-		refLog.addTable(targetTableName, refId, version, sourceTableRef.getColumns().entrySet().stream()
-				.map(Entry::getValue)
+		refLog.addTable(targetTableName, refId, version, sourceTableRef.getColumns().values().stream()
 				.map(ColumnRef::ghost)
 				.collect(Collectors.toList()));
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CreateTableMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CreateTableMigrator.java
@@ -27,6 +27,7 @@ class CreateTableMigrator implements SchemaOperationMigrator<CreateTable> {
 
 		Table table = new Table(refId);
 		operation.getColumns().forEach(c -> table.addColumn(c.createColumn()));
+		operation.getUniques().forEach(table::addUnique);
 
 		catalog.addTable(table);
 	}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
@@ -16,7 +16,9 @@ import io.quantumdb.core.versioning.RefLog.TableRef;
 import io.quantumdb.core.versioning.Version;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class TransitiveTableMirrorer {
 
@@ -28,6 +30,8 @@ class TransitiveTableMirrorer {
 		List<TableRef> tablesToMirror = Arrays.stream(tableNames)
 				.map(tableName -> refLog.getTableRef(parentVersion, tableName))
 				.collect(Collectors.toList());
+
+		log.debug("These tables are mirrored {}", tablesToMirror);
 
 		while(!tablesToMirror.isEmpty()) {
 			TableRef tableRef = tablesToMirror.remove(0);
@@ -71,6 +75,8 @@ class TransitiveTableMirrorer {
 						.referencing(newReferredTable, foreignKey.getReferredColumns());
 			}
 		}
+
+		// ToDo recreate any existing indexes concurrently
 
 		return mirrored;
 	}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
@@ -49,7 +49,7 @@ class TransitiveTableMirrorer {
 			// Traverse incoming foreign keys
 			Set<String> referencingRefIds = catalog.getTablesReferencingTable(tableRef.getRefId());
 			tablesToMirror.addAll(referencingRefIds.stream()
-					.map(refId -> refLog.getTableRefById(refId))
+					.map(refLog::getTableRefById)
 					.collect(Collectors.toList()));
 		}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Catalog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Catalog.java
@@ -36,7 +36,8 @@ public class Catalog implements Copyable<Catalog> {
 		checkArgument(!containsTable(table.getName()), "Catalog: '" + name + "' already contains a table: '" + table.getName() + "'.");
 		checkArgument(!containsView(table.getName()), "Catalog: '" + name + "' already contains a view: '" + table.getName() + "'.");
 		checkArgument(!table.getColumns().isEmpty(), "Table: '" + table.getName() + "' doesn't contain any columns.");
-		checkArgument(!table.getIdentityColumns().isEmpty(), "Table: '" + table.getName() + "' has no identity columns.");
+		// ToDo look into migration without primary keys
+		checkArgument(!table.getPrimaryKeyColumns().isEmpty(), "Table: '" + table.getName() + "' has no primary key columns.");
 
 		tables.add(table);
 		table.setParent(this);
@@ -47,9 +48,7 @@ public class Catalog implements Copyable<Catalog> {
 		checkArgument(!Strings.isNullOrEmpty(tableName), "You must specify a 'tableName'");
 
 		return tables.stream()
-				.filter(t -> t.getName().equals(tableName))
-				.findFirst()
-				.isPresent();
+				.anyMatch(t -> t.getName().equals(tableName));
 	}
 
 	public Table getTable(String tableName) {
@@ -87,9 +86,7 @@ public class Catalog implements Copyable<Catalog> {
 		checkArgument(!Strings.isNullOrEmpty(viewName), "You must specify a 'viewName'");
 
 		return views.stream()
-				.filter(v -> v.getName().equals(viewName))
-				.findFirst()
-				.isPresent();
+				.anyMatch(v -> v.getName().equals(viewName));
 	}
 
 	public View getView(String viewName) {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Column.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Column.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 public class Column implements Copyable<Column> {
 
 	public static enum Hint {
-		NOT_NULL, AUTO_INCREMENT, IDENTITY;
+		NOT_NULL, AUTO_INCREMENT, UNIQUE, PRIMARY_KEY;
 	}
 
 	private String name;
@@ -93,8 +93,12 @@ public class Column implements Copyable<Column> {
 		this.defaultValue = null;
 	}
 
-	public boolean isIdentity() {
-		return hints.contains(Hint.IDENTITY);
+	public boolean isPrimaryKey() {
+		return hints.contains(Hint.PRIMARY_KEY);
+	}
+
+	public boolean isUnique() {
+		return hints.contains(Hint.UNIQUE);
 	}
 
 	public boolean isAutoIncrement() {
@@ -126,7 +130,7 @@ public class Column implements Copyable<Column> {
 
 	@Override
 	public Column copy() {
-		return new Column(name, type, sequence, defaultValue, hints.stream().toArray(Hint[]::new));
+		return new Column(name, type, sequence, defaultValue, hints.toArray(Hint[]::new));
 	}
 
 	@Override

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ColumnType.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ColumnType.java
@@ -16,6 +16,7 @@ public class ColumnType {
 		TEXT,
 		SMALLINT,
 		INTEGER,
+		NUMERIC,
 		BIGINT,
 		DOUBLE,
 		FLOAT,

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ColumnType.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ColumnType.java
@@ -16,13 +16,15 @@ public class ColumnType {
 		TEXT,
 		SMALLINT,
 		INTEGER,
+		DECIMAL,
 		NUMERIC,
 		BIGINT,
 		DOUBLE,
 		FLOAT,
 		BOOLEAN,
 		DATE,
-		TIMESTAMP
+		TIMESTAMP,
+		BYTEA
 	}
 
 	@FunctionalInterface

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ForeignKey.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ForeignKey.java
@@ -102,7 +102,7 @@ public class ForeignKey {
 	}
 
 	public boolean isInheritanceRelation() {
-		Set<String> identityColumns = getReferencingTable().getIdentityColumns().stream()
+		Set<String> identityColumns = getReferencingTable().getPrimaryKeyColumns().stream()
 				.map(Column::getName)
 				.collect(Collectors.toSet());
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Index.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Index.java
@@ -23,7 +23,7 @@ public class Index {
 	}
 
 	public Index(String indexName, List<String> columns, boolean unique) {
-		checkArgument(!isNullOrEmpty(indexName), "You must specify a 'foreignKeyName'.");
+		checkArgument(!isNullOrEmpty(indexName), "You must specify an 'indexName'.");
 		checkArgument(columns != null && !columns.isEmpty(), "You must specify at least one column.");
 
 		this.indexName = indexName;

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Table.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Table.java
@@ -3,10 +3,7 @@ package io.quantumdb.core.schema.definitions;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
@@ -21,7 +18,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Setter;
 
 @Data
-@EqualsAndHashCode(exclude = { "parent", "foreignKeys", "indexes" })
+@EqualsAndHashCode(exclude = { "parent", "foreignKeys", "indexes", "uniques" })
 @Setter(AccessLevel.NONE)
 public class Table implements Copyable<Table>, Comparable<Table> {
 
@@ -79,6 +76,7 @@ public class Table implements Copyable<Table>, Comparable<Table> {
 	private final LinkedHashSet<Column> columns = Sets.newLinkedHashSet();
 	private final List<ForeignKey> foreignKeys = Lists.newArrayList();
 	private final List<Index> indexes = Lists.newArrayList();
+	private final List<Unique> uniques = Lists.newArrayList();
 
 	public Table(String name) {
 		checkArgument(!Strings.isNullOrEmpty(name), "You must specify a 'name'.");
@@ -148,6 +146,56 @@ public class Table implements Copyable<Table>, Comparable<Table> {
 		return ImmutableList.copyOf(indexes);
 	}
 
+	public Table addUnique(Unique unique) {
+		checkArgument(unique != null, "You must specify a 'unique'.");
+		checkState(!containsUnique(unique.getUniqueName()), "Table already contains a unique with name: " + unique.getUniqueName());
+
+		uniques.add(unique);
+		unique.setParent(this);
+		return this;
+	}
+
+	public boolean containsUnique(String... columns) {
+		return containsUnique(Sets.newHashSet(columns));
+	}
+
+	public boolean containsUnique(Collection<String> columns) {
+		checkArgument(!columns.isEmpty(), "You must specify at least one entry in 'columns'.");
+
+		return uniques.stream()
+				.anyMatch(c -> c.getColumns().equals(Lists.newArrayList(columns)));
+	}
+
+	public Unique removeUnique(String... columns) {
+		return removeUnique(Sets.newHashSet(columns));
+	}
+
+	public Unique removeUnique(Collection<String> columns) {
+		checkState(containsUnique(columns), "You cannot remove a unique which does not exist: " + columns);
+
+		Unique unique = getUnique(columns);
+		unique.setParent(null);
+		uniques.remove(unique);
+		return unique;
+	}
+
+	public Unique getUnique(String... columns) {
+		return getUnique(Sets.newHashSet(columns));
+	}
+
+	public Unique getUnique(Collection<String> columns) {
+		checkArgument(!columns.isEmpty(), "You must specify at least one 'columns'.");
+
+		return uniques.stream()
+				.filter(c -> c.getColumns().equals(Lists.newArrayList(columns)))
+				.findFirst()
+				.orElse(null);
+	}
+
+	public ImmutableList<Unique> getUniques() {
+		return ImmutableList.copyOf(uniques);
+	}
+	
 	public Table addColumn(Column column) {
 		checkArgument(column != null, "You must specify a 'column'.");
 		checkState(!containsColumn(column.getName()), "Table already contains a column with name: " + column.getName());

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Unique.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Unique.java
@@ -1,0 +1,37 @@
+package io.quantumdb.core.schema.definitions;
+
+import io.quantumdb.core.utils.RandomHasher;
+import lombok.Data;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+@Data
+public class Unique {
+
+    private transient final String uniqueName;
+
+    private final List<String> columns;
+
+    private Table parent;
+
+    public Unique(List<String> columns) {
+        this("unique_" + RandomHasher.generateHash(), columns);
+    }
+
+    public Unique(String uniqueName, List<String> columns) {
+        checkArgument(!isNullOrEmpty(uniqueName), "You must specify a 'uniqueName'.");
+        checkArgument(columns != null && !columns.isEmpty(), "You must specify at least one column.");
+
+        this.uniqueName = uniqueName;
+        this.columns = columns;
+    }
+
+    @Override
+    public String toString() {
+        return PrettyPrinter.prettyPrint(this);
+    }
+
+}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/ColumnDefinition.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/ColumnDefinition.java
@@ -54,6 +54,10 @@ public class ColumnDefinition {
 		return containsHint(Column.Hint.NOT_NULL);
 	}
 
+	public boolean isUnique() {
+		return containsHint(Column.Hint.UNIQUE);
+	}
+
 	private boolean containsHint(Column.Hint needle) {
 		return Arrays.stream(hints)
 				.anyMatch(hint -> hint == needle);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/ColumnDefinition.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/ColumnDefinition.java
@@ -42,8 +42,8 @@ public class ColumnDefinition {
 		this.hints = hints;
 	}
 
-	public boolean isIdentity() {
-		return containsHint(Column.Hint.IDENTITY);
+	public boolean isPrimaryKey() {
+		return containsHint(Column.Hint.PRIMARY_KEY);
 	}
 
 	public boolean isAutoIncrement() {
@@ -56,9 +56,7 @@ public class ColumnDefinition {
 
 	private boolean containsHint(Column.Hint needle) {
 		return Arrays.stream(hints)
-				.filter(hint -> hint == needle)
-				.findFirst()
-				.isPresent();
+				.anyMatch(hint -> hint == needle);
 	}
 
 	public Column createColumn() {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/CreateTable.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/CreateTable.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.quantumdb.core.schema.definitions.Column.Hint;
 import io.quantumdb.core.schema.definitions.ColumnType;
+import io.quantumdb.core.schema.definitions.Unique;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -22,11 +23,13 @@ public class CreateTable implements SchemaOperation {
 
 	private final String tableName;
 	private final List<ColumnDefinition> columns;
+	private final List<Unique> uniques;
 
 	CreateTable(String tableName) {
 		checkArgument(!Strings.isNullOrEmpty(tableName), "You must specify a 'tableName'.");
 		this.tableName = tableName;
 		this.columns = Lists.newArrayList();
+		this.uniques = Lists.newArrayList();
 	}
 
 	public CreateTable with(String name, ColumnType type, Hint... hints) {
@@ -38,6 +41,13 @@ public class CreateTable implements SchemaOperation {
 		checkArgument(type != null, "You must specify a 'type'.");
 
 		columns.add(new ColumnDefinition(name, type, defaultValueExpression, hints));
+		return this;
+	}
+
+	public CreateTable withUnique(Unique unique) {
+		checkArgument(unique != null, "The unique is null.");
+		checkArgument(!this.uniques.contains(unique), "This table already contains that unique object.");
+		this.uniques.add(unique);
 		return this;
 	}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/ChangeSet.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/ChangeSet.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 
 
 /**
- * This class describes a list of SchemaOperations which batched together form a logical set of changes to the database
+ * This class describes a list of SchemaOperations which, when batched together, form a logical set of changes to the database
  * schema. This batch can optionally be given a description, much like a commit message in version control systems.
  */
 @Data

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
@@ -26,6 +26,9 @@ import lombok.Setter;
 @EqualsAndHashCode(exclude = { "idGenerator" })
 public class Changelog {
 
+	/**
+	 * The root Version of the Changelog
+	 */
 	private final Version root;
 
 	@Getter(AccessLevel.NONE)

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/RefLog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/RefLog.java
@@ -160,7 +160,6 @@ public class RefLog {
 			return columns.values().stream()
 					.flatMap(column -> column.getBasedOn().stream())
 					.map(ColumnRef::getTable)
-					.distinct()
 					.collect(Collectors.toSet());
 		}
 
@@ -168,7 +167,6 @@ public class RefLog {
 			return columns.values().stream()
 					.flatMap(column -> column.getBasisFor().stream())
 					.map(ColumnRef::getTable)
-					.distinct()
 					.collect(Collectors.toSet());
 		}
 
@@ -828,7 +826,9 @@ public class RefLog {
 	 * @return The mapping between TableRefs between these two versions.
 	 */
 	public Multimap<TableRef, TableRef> getTableMapping(Version from, Version to, boolean filterUnchanged) {
+		log.debug("Getting table mapping from {} to {}", from.getId(), to.getId());
 		Multimap<TableRef, TableRef> mapping = HashMultimap.create();
+		log.debug("TableRefs existing in from version: {}", getTableRefs(from));
 		getTableRefs(from).forEach(tableRef -> {
 			Set<TableRef> targets = Sets.newHashSet();
 			List<TableRef> toCheck = Lists.newLinkedList();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/RefLog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/RefLog.java
@@ -26,8 +26,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Slf4j
 @ToString

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddColumnMigratorTest.java
@@ -1,8 +1,6 @@
 package io.quantumdb.core.migration.operations;
 
-import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
-import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
+import static io.quantumdb.core.schema.definitions.Column.Hint.*;
 import static io.quantumdb.core.schema.definitions.TestTypes.bool;
 import static io.quantumdb.core.schema.definitions.TestTypes.date;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
@@ -31,7 +29,7 @@ public class AddColumnMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -50,7 +48,7 @@ public class AddColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("date_of_birth", date(), "NULL"));
 
@@ -71,7 +69,7 @@ public class AddColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("date_of_birth", date(), "NULL"))
 				.addColumn(new Column("activated", bool(), "TRUE"));

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddForeignKeyMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddForeignKeyMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,10 +29,10 @@ public class AddForeignKeyMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)))
 				.addTable(new Table("posts")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("author", integer(), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -51,7 +51,7 @@ public class AddForeignKeyMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("author", integer(), NOT_NULL));
 
 		expectedGhostTable.addForeignKey("author").referencing(usersTable, "id");

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AlterColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AlterColumnMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.text;
@@ -31,10 +31,10 @@ public class AlterColumnMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)))
 				.addTable(new Table("referrals")
-						.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("invited_by_id", integer())));
 
 		this.changelog = new Changelog();
@@ -53,7 +53,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("full_name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -69,7 +69,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", text(), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -85,7 +85,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), "'Unknown'", NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -103,7 +103,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), "'John Smith'", NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -121,7 +121,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -137,7 +137,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("invited_by_id", integer(), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -153,7 +153,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, AUTO_INCREMENT))
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, AUTO_INCREMENT))
 				.addColumn(new Column("invited_by_id", integer()));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -169,7 +169,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("invited_by_id", integer(), AUTO_INCREMENT));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -185,7 +185,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL))
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL))
 				.addColumn(new Column("invited_by_id", integer()));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -193,16 +193,16 @@ public class AlterColumnMigratorTest {
 
 	@Test
 	public void testExpandForAddingIdentityHint() {
-		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invited_by_id").addHint(IDENTITY);
-		changelog.addChangeSet("Michael de Jong", "Added IDENTITY constraint to 'invited_by_id' column.", operation);
+		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invited_by_id").addHint(PRIMARY_KEY);
+		changelog.addChangeSet("Michael de Jong", "Added PRIMARY_KEY constraint to 'invited_by_id' column.", operation);
 		migrator.migrate(catalog, refLog, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
-				.addColumn(new Column("invited_by_id", integer(), IDENTITY));
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("invited_by_id", integer(), PRIMARY_KEY));
 
 		assertEquals(expectedGhostTable, ghostTable);
 	}
@@ -211,8 +211,8 @@ public class AlterColumnMigratorTest {
 	public void testExpandForRemovingIdentityHint() {
 		testExpandForAddingIdentityHint();
 
-		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invitee_id").dropHint(IDENTITY);
-		changelog.addChangeSet("Michael de Jong", "Dropped IDENTITY constraint of 'invitee_id' column.", operation);
+		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invitee_id").dropHint(PRIMARY_KEY);
+		changelog.addChangeSet("Michael de Jong", "Dropped PRIMARY_KEY constraint of 'invitee_id' column.", operation);
 		migrator.migrate(catalog, refLog, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
@@ -220,7 +220,7 @@ public class AlterColumnMigratorTest {
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
 				.addColumn(new Column("invitee_id", integer(), AUTO_INCREMENT, NOT_NULL))
-				.addColumn(new Column("invited_by_id", integer(), IDENTITY));
+				.addColumn(new Column("invited_by_id", integer(), PRIMARY_KEY));
 
 		assertEquals(expectedGhostTable, ghostTable);
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CopyTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CopyTableMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -28,7 +28,7 @@ public class CopyTableMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -50,12 +50,12 @@ public class CopyTableMigratorTest {
 		String refId = refLog.getTableRef(changelog.getLastAdded(), "customers").getRefId();
 		Table ghostTable = catalog.getTable(refId);
 		Table expectedGhostTable = new Table(refId)
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table originalTable = catalog.getTable("users");
 		Table expectedOriginalTable = new Table("users")
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CreateTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CreateTableMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -37,7 +37,7 @@ public class CreateTableMigratorTest {
 	@Test
 	public void testExpandForCopyingTable() {
 		CreateTable operation = SchemaOperations.createTable("users")
-				.with("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
+				.with("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL)
 				.with("name", varchar(255), NOT_NULL);
 
 		changelog.addChangeSet("Michael de Jong", "Creating 'users' table.", operation);
@@ -47,7 +47,7 @@ public class CreateTableMigratorTest {
 		String refId = tableRef.getRefId();
 		Table ghostTable = catalog.getTable(refId);
 		Table expectedGhostTable = new Table(refId)
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropColumnMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,7 +29,7 @@ public class DropColumnMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -48,7 +48,7 @@ public class DropColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		assertEquals(expectedGhostTable, ghostTable);
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropForeignKeyMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropForeignKeyMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,10 +29,10 @@ public class DropForeignKeyMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)))
 				.addTable(new Table("posts")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("author", integer(), NOT_NULL)));
 
 		Table posts = catalog.getTable("posts");
@@ -57,7 +57,7 @@ public class DropForeignKeyMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("author", integer(), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropTableMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,7 +29,7 @@ public class DropTableMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/RenameTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/RenameTableMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,7 +29,7 @@ public class RenameTableMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -47,7 +47,7 @@ public class RenameTableMigratorTest {
 		String refId = refLog.getTableRef(changelog.getLastAdded(), "customers").getRefId();
 		Table ghostTable = catalog.getTable(refId);
 		Table expectedGhostTable = new Table(refId)
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/SchemaOperationMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/SchemaOperationMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.operations.SchemaOperations.createTable;
@@ -36,7 +36,7 @@ public class SchemaOperationMigratorTest {
 	public void testAddingNewTable() {
 		changelog.addChangeSet("test", "Michael de Jong",
 				createTable("users")
-						.with("id", bigint(), NOT_NULL, AUTO_INCREMENT, IDENTITY));
+						.with("id", bigint(), NOT_NULL, AUTO_INCREMENT, PRIMARY_KEY));
 
 		Version current = changelog.getLastAdded();
 		migrator.migrate(current, (SchemaOperation) current.getOperation());
@@ -44,7 +44,7 @@ public class SchemaOperationMigratorTest {
 		String refId = refLog.getTableRef(current, "users").getRefId();
 
 		Table expected = new Table(refId)
-				.addColumn(new Column("id", bigint(), NOT_NULL, AUTO_INCREMENT, IDENTITY));
+				.addColumn(new Column("id", bigint(), NOT_NULL, AUTO_INCREMENT, PRIMARY_KEY));
 
 		assertEquals(expected, catalog.getTable(refId));
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/CatalogTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/CatalogTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.schema.definitions;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static org.junit.Assert.assertEquals;
@@ -39,7 +39,7 @@ public class CatalogTest {
 	@Test
 	public void testAddingTableToCatalog() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -50,7 +50,7 @@ public class CatalogTest {
 	@Test
 	public void testThatContainsTableMethodReturnsTrueWhenTableExists() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -80,7 +80,7 @@ public class CatalogTest {
 	@Test
 	public void testThatGetTableMethodReturnsTableWhenItExists() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -109,7 +109,7 @@ public class CatalogTest {
 	@Test
 	public void testThatRemoveTableMethodRemovesTableWhenItExists() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -141,11 +141,11 @@ public class CatalogTest {
 	public void testRemovingTableDropsOutgoingForeignKeys() {
 		Catalog catalog = new Catalog("test-db");
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		catalog.addTable(users);
 		catalog.addTable(addresses);
@@ -163,11 +163,11 @@ public class CatalogTest {
 	public void testRemovingTableThrowsExceptionWhenIncomingForeignKeysExist() {
 		Catalog catalog = new Catalog("test-db");
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		catalog.addTable(users);
 		catalog.addTable(addresses);
@@ -181,7 +181,7 @@ public class CatalogTest {
 	@Test
 	public void testThatRenamingTableIsReflectedInCatalog() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -196,10 +196,10 @@ public class CatalogTest {
 	@Test(expected = IllegalStateException.class)
 	public void testThatRenamingTableThrowsExceptionWhenNameIsAlreadyTaken() {
 		Table usersTable = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Table playersTable = new Table("players")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		new Catalog("test-db")
 				.addTable(usersTable)
@@ -211,7 +211,7 @@ public class CatalogTest {
 	@Test
 	public void testThatCopyMethodReturnsCopy() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -225,7 +225,7 @@ public class CatalogTest {
 	@Test
 	public void toStringReturnsSomething() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/ColumnTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/ColumnTest.java
@@ -75,7 +75,7 @@ public class ColumnTest {
 	public void testGetParentReturnsNullWhenColumnDoesNotBelongToTable() {
 		Column column = new Column("id", bigint());
 
-		assertEquals(null, column.getParent());
+		assertNull(column.getParent());
 	}
 
 	@Test
@@ -90,11 +90,11 @@ public class ColumnTest {
 	@Test
 	public void testAddingForeignKeyToSingleColumn() {
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		ForeignKey constraint = users.addForeignKey("address_id")
 				.referencing(addresses, "id");
@@ -110,22 +110,22 @@ public class ColumnTest {
 	@Test
 	public void testAddingForeignKeyToMultiColumn() {
 		Table items = new Table("items")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		Table locations = new Table("locations")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		Table stocks = new Table("stocks")
-				.addColumn(new Column("item_id", bigint(), IDENTITY, NOT_NULL))
-				.addColumn(new Column("location_id", bigint(), IDENTITY, NOT_NULL))
+				.addColumn(new Column("item_id", bigint(), PRIMARY_KEY, NOT_NULL))
+				.addColumn(new Column("location_id", bigint(), PRIMARY_KEY, NOT_NULL))
 				.addColumn(new Column("quantity", bigint(), NOT_NULL));
 
 		stocks.addForeignKey("item_id").referencing(items, "id");
 		stocks.addForeignKey("location_id").referencing(locations, "id");
 
 		Table stockNotes = new Table("stock_notes")
-				.addColumn(new Column("item_id", bigint(), IDENTITY, NOT_NULL))
-				.addColumn(new Column("location_id", bigint(), IDENTITY, NOT_NULL))
+				.addColumn(new Column("item_id", bigint(), PRIMARY_KEY, NOT_NULL))
+				.addColumn(new Column("location_id", bigint(), PRIMARY_KEY, NOT_NULL))
 				.addColumn(new Column("notes", varchar(255), NOT_NULL));
 
 		ForeignKey constraint = stockNotes.addForeignKey("item_id", "location_id")
@@ -144,11 +144,11 @@ public class ColumnTest {
 	@Test
 	public void testRemovingColumnWithOutgoingForeignKey() {
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		users.addForeignKey("address_id")
 				.referencing(addresses, "id");
@@ -163,11 +163,11 @@ public class ColumnTest {
 	@Test(expected = IllegalStateException.class)
 	public void testRemovingColumnWithIncomingForeignKey() {
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("serial_id", bigint()));
 
 		users.addForeignKey("address_id")
@@ -210,7 +210,7 @@ public class ColumnTest {
 
 	@Test
 	public void testThatCopyMethodReturnsCopy() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL);
 		Column copy = column.copy();
 
 		assertEquals(column, copy);
@@ -219,7 +219,7 @@ public class ColumnTest {
 
 	@Test
 	public void toStringReturnsSomething() {
-		Column column = new Column("id", bigint(), "'0'", IDENTITY, NOT_NULL);
+		Column column = new Column("id", bigint(), "'0'", PRIMARY_KEY, NOT_NULL);
 
 		assertFalse(Strings.isNullOrEmpty(column.toString()));
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/ColumnTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/ColumnTest.java
@@ -25,9 +25,9 @@ public class ColumnTest {
 
 	@Test
 	public void testCreatingIdentityColumn() {
-		Column column = new Column("id", bigint(), IDENTITY);
+		Column column = new Column("id", bigint(), PRIMARY_KEY);
 
-		assertTrue(column.isIdentity());
+		assertTrue(column.isPrimaryKey());
 	}
 
 	@Test
@@ -42,6 +42,13 @@ public class ColumnTest {
 		Column column = new Column("id", bigint(), NOT_NULL);
 
 		assertTrue(column.isNotNull());
+	}
+
+	@Test
+	public void testCreatingUniqueColumn() {
+		Column column = new Column("id", bigint(), UNIQUE);
+
+		assertTrue(column.isUnique());
 	}
 
 	@Test

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/ColumnTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/ColumnTest.java
@@ -1,13 +1,9 @@
 package io.quantumdb.core.schema.definitions;
 
-import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
-import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
+import static io.quantumdb.core.schema.definitions.Column.Hint.*;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.google.common.base.Strings;
 import org.junit.Test;
@@ -20,7 +16,7 @@ public class ColumnTest {
 
 		assertEquals("id", column.getName());
 		assertEquals(bigint(), column.getType());
-		assertEquals(null, column.getDefaultValue());
+		assertNull(column.getDefaultValue());
 	}
 
 	@Test
@@ -221,7 +217,7 @@ public class ColumnTest {
 		Column copy = column.copy();
 
 		assertEquals(column, copy);
-		assertFalse(column == copy);
+		assertNotSame(column, copy);
 	}
 
 	@Test

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/TableTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/TableTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.schema.definitions;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.definitions.TestTypes.bool;
@@ -41,20 +41,20 @@ public class TableTest {
 
 	@Test
 	public void testAddingColumnToTable() {
-		new Table("users").addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+		new Table("users").addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 	}
 
 	@Test(expected = IllegalStateException.class)
 	public void testThatAddingColumnWithAnAlreadyTakenNameToTableThrowsException() {
 		new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT))
 				.addColumn(new Column("id", varchar(255)));
 	}
 
 	@Test
 	public void testAddingMutipleColumnsToTable() {
 		new Table("users").addColumns(Lists.newArrayList(
-				new Column("id", bigint(), IDENTITY, AUTO_INCREMENT),
+				new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT),
 				new Column("name", varchar(255), NOT_NULL)
 		));
 	}
@@ -67,7 +67,7 @@ public class TableTest {
 	@Test
 	public void testThatContainsColumnMethodReturnsTrueWhenColumnExists() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		assertTrue(table.containsColumn("id"));
 	}
@@ -93,7 +93,7 @@ public class TableTest {
 
 	@Test
 	public void testThatGetColumnMethodReturnsColumnWhenItExists() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 
 		assertEquals(column, table.getColumn("id"));
@@ -122,36 +122,36 @@ public class TableTest {
 		Table table = new Table("users")
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
-		assertTrue(table.getIdentityColumns().isEmpty());
+		assertTrue(table.getPrimaryKeyColumns().isEmpty());
 	}
 
 	@Test
 	public void testThatGetIdentityColumnMethodReturnsOneColumnForTableWithSinglePrimaryKey() {
-		Column idColumn = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column idColumn = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 
 		Table table = new Table("users")
 				.addColumn(idColumn)
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
-		assertEquals(Lists.newArrayList(idColumn), table.getIdentityColumns());
+		assertEquals(Lists.newArrayList(idColumn), table.getPrimaryKeyColumns());
 	}
 
 	@Test
 	public void testThatGetIdentityColumnMethodReturnsOneColumnForTableWithCompositeKey() {
-		Column id1Column = new Column("left_id", bigint(), IDENTITY, AUTO_INCREMENT);
-		Column id2Column = new Column("right_id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column id1Column = new Column("left_id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
+		Column id2Column = new Column("right_id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 
 		Table table = new Table("link_table")
 				.addColumn(id1Column)
 				.addColumn(id2Column)
 				.addColumn(new Column("some_property", bool(), NOT_NULL));
 
-		assertEquals(Lists.newArrayList(id1Column, id2Column), table.getIdentityColumns());
+		assertEquals(Lists.newArrayList(id1Column, id2Column), table.getPrimaryKeyColumns());
 	}
 
 	@Test
 	public void testThatRemoveColumnMethodRemovesColumnWhenItExists() {
-		Column column1 = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column1 = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Column column2 = new Column("name", varchar(255), NOT_NULL);
 		Table table = new Table("users").addColumn(column1).addColumn(column2);
 
@@ -180,7 +180,7 @@ public class TableTest {
 
 	@Test
 	public void testThatRenamingColumnIsReflectedInTable() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 
 		column.rename("uuid");
@@ -198,21 +198,21 @@ public class TableTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testThatRenamingTableToNullThrowsException() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 		table.rename(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testThatRenamingColumnToEmptyStringThrowsException() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 		table.rename("");
 	}
 
 	@Test
 	public void testThatCopyMethodReturnsCopy() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 
 		Table copy = table.copy();
@@ -224,7 +224,7 @@ public class TableTest {
 	@Test
 	public void toStringReturnsSomething() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		assertFalse(Strings.isNullOrEmpty(table.toString()));
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/operations/CreateTableTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/operations/CreateTableTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.schema.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -17,10 +17,10 @@ public class CreateTableTest {
 	@Test
 	public void testCreatingTableWithDefaultExpression() {
 		CreateTable operation = SchemaOperations.createTable("addresses")
-				.with("id", bigint(), "'1'", IDENTITY, NOT_NULL);
+				.with("id", bigint(), "'1'", PRIMARY_KEY, NOT_NULL);
 
 		List<ColumnDefinition> expectedColumns = Lists.newArrayList(
-				new ColumnDefinition("id", bigint(), "'1'", IDENTITY, NOT_NULL));
+				new ColumnDefinition("id", bigint(), "'1'", PRIMARY_KEY, NOT_NULL));
 
 		assertEquals("addresses", operation.getTableName());
 		assertEquals(expectedColumns, operation.getColumns());
@@ -29,7 +29,7 @@ public class CreateTableTest {
 	@Test
 	public void testCreatingTableWithMultipleColumns() {
 		CreateTable operation = SchemaOperations.createTable("addresses")
-				.with("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
+				.with("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL)
 				.with("street", varchar(255), NOT_NULL)
 				.with("street_number", varchar(10), NOT_NULL)
 				.with("city", varchar(255), NOT_NULL)
@@ -37,7 +37,7 @@ public class CreateTableTest {
 				.with("country", varchar(255), NOT_NULL);
 
 		List<ColumnDefinition> expectedColumns = Lists.newArrayList(
-				new ColumnDefinition("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL),
+				new ColumnDefinition("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL),
 				new ColumnDefinition("street", varchar(255), NOT_NULL),
 				new ColumnDefinition("street_number", varchar(10), NOT_NULL),
 				new ColumnDefinition("city", varchar(255), NOT_NULL),
@@ -62,19 +62,19 @@ public class CreateTableTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreatingTableWithNullForColumnName() {
 		SchemaOperations.createTable("addresses")
-				.with(null, bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL);
+				.with(null, bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreatingTableWithEmptyStringForColumnName() {
 		SchemaOperations.createTable("addresses")
-				.with("", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL);
+				.with("", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreatingTableWithNullForColumnType() {
 		SchemaOperations.createTable("addresses")
-				.with("id", null, IDENTITY, AUTO_INCREMENT, NOT_NULL);
+				.with("id", null, PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL);
 	}
 
 }

--- a/quantumdb-core/src/test/java/io/quantumdb/core/state/RefLogTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/state/RefLogTest.java
@@ -1,6 +1,6 @@
 package io.quantumdb.core.state;
 
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
 import static io.quantumdb.core.utils.RandomHasher.generateHash;
@@ -38,7 +38,7 @@ public class RefLogTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db");
 		catalog.addTable(new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY))
 				.addColumn(new Column("name", varchar(255))));
 
 		this.version = new Version(generateHash(), null);

--- a/quantumdb-driver/pom.xml
+++ b/quantumdb-driver/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>io.quantumdb</groupId>
 		<artifactId>quantumdb</artifactId>
-		<version>0.4.1-SNAPSHOT</version>
+		<version>0.4.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>quantumdb-driver</artifactId>
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.3.0</version>
 				<configuration>
 					<archive>
 						<manifest>

--- a/quantumdb-postgresql/pom.xml
+++ b/quantumdb-postgresql/pom.xml
@@ -4,19 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-				<version>3.8.1</version>
-			</plugin>
-		</plugins>
-	</build>
 
 	<parent>
 		<groupId>io.quantumdb</groupId>

--- a/quantumdb-postgresql/pom.xml
+++ b/quantumdb-postgresql/pom.xml
@@ -4,11 +4,24 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+				<version>3.8.1</version>
+			</plugin>
+		</plugins>
+	</build>
 
 	<parent>
 		<groupId>io.quantumdb</groupId>
 		<artifactId>quantumdb</artifactId>
-		<version>0.4.1-SNAPSHOT</version>
+		<version>0.4.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>quantumdb-postgresql</artifactId>
@@ -20,15 +33,16 @@
 			<artifactId>quantumdb-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.3-1101-jdbc41</version>
+			<version>42.2.20</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.3</version>
+			<version>2.8.6</version>
 		</dependency>
 	</dependencies>
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/NullRecords.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/NullRecords.java
@@ -104,7 +104,7 @@ public class NullRecords {
 
 	private Identity insertNullObject(Connection connection, Table table, Map<String, Identity> generatedIdentities) throws SQLException {
 		List<Column> columnsToSet = table.getColumns().stream()
-				.filter(column -> column.isIdentity() || column.isNotNull())
+				.filter(column -> column.isPrimaryKey() || column.isNotNull())
 				.collect(Collectors.toList());
 
 		List<String> columnNames = columnsToSet.stream()
@@ -139,7 +139,7 @@ public class NullRecords {
 				String columnName = column.getName();
 				ForeignKey outgoingForeignKey = column.getOutgoingForeignKey();
 
-				if (column.isIdentity()) {
+				if (column.isPrimaryKey()) {
 					Object value = identity.getValue(columnName);
 					valueSetter.setValue(statement, i, value);
 					values.put(column.getName(), value);
@@ -178,7 +178,7 @@ public class NullRecords {
 		Identity identity = new Identity();
 		generatedIdentities.put(table.getName(), identity);
 
-		for (Column identityColumn : table.getIdentityColumns()) {
+		for (Column identityColumn : table.getPrimaryKeyColumns()) {
 			ForeignKey outgoingForeignKey = identityColumn.getOutgoingForeignKey();
 			if (identityColumn.isAutoIncrement()) {
 				Sequence sequence = identityColumn.getSequence();

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlMigrationPlanner.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlMigrationPlanner.java
@@ -388,15 +388,8 @@ public class PostgresqlMigrationPlanner implements MigrationPlanner {
 				}
 
 				for (ForeignKey foreignKey : table.getForeignKeys()) {
-					if (operationType == Type.COPY) {
-						if (!foreignKey.isNotNullable() && !foreignKey.isInheritanceRelation()) {
-							continue;
-						}
-					}
-					else if (operationType == Type.ADD_NULL) {
-						if (!foreignKey.isNotNullable() && !foreignKey.isInheritanceRelation()) {
-							continue;
-						}
+					if (!foreignKey.isNotNullable() && !foreignKey.isInheritanceRelation()) {
+						continue;
 					}
 
 					Table otherTable = foreignKey.getReferredTable();

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlMigrationPlanner.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlMigrationPlanner.java
@@ -201,7 +201,7 @@ public class PostgresqlMigrationPlanner implements MigrationPlanner {
 						.map(Column::getName)
 						.collect(Collectors.toCollection(Sets::newLinkedHashSet));
 
-				Set<String> identityColumns = table.getIdentityColumns().stream()
+				Set<String> identityColumns = table.getPrimaryKeyColumns().stream()
 						.map(Column::getName)
 						.collect(Collectors.toSet());
 
@@ -209,7 +209,7 @@ public class PostgresqlMigrationPlanner implements MigrationPlanner {
 				if (!missingIdentityColumns.isEmpty()) {
 					toMigrate.add(0, refId);
 
-					List<Table> parentTables = table.getIdentityColumns().stream()
+					List<Table> parentTables = table.getPrimaryKeyColumns().stream()
 							.map(Column::getOutgoingForeignKey)
 							.map(ForeignKey::getReferredTable)
 							.distinct()
@@ -287,7 +287,7 @@ public class PostgresqlMigrationPlanner implements MigrationPlanner {
 						.map(Column::getName)
 						.collect(Collectors.toCollection(Sets::newLinkedHashSet));
 
-				Set<String> identityColumns = table.getIdentityColumns().stream()
+				Set<String> identityColumns = table.getPrimaryKeyColumns().stream()
 						.map(Column::getName)
 						.collect(Collectors.toSet());
 
@@ -295,7 +295,7 @@ public class PostgresqlMigrationPlanner implements MigrationPlanner {
 				if (!missingIdentityColumns.isEmpty()) {
 					toMigrate.add(0, refId);
 
-					List<Table> parentTables = table.getIdentityColumns().stream()
+					List<Table> parentTables = table.getPrimaryKeyColumns().stream()
 							.map(Column::getOutgoingForeignKey)
 							.map(ForeignKey::getReferredTable)
 							.distinct()

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
@@ -109,8 +109,8 @@ public class SelectiveMigratorFunction {
 					Column newColumn = target.getColumn(newColumnName);
 					return new SimpleImmutableEntry<>(newColumn, entry.getKey().getName());
 				})
-				.collect(Collectors.toMap(entry -> "\"" + entry.getKey().getName() + "\"",
-						entry -> "\"" + entry.getValue() + "\""));
+				.collect(Collectors.toMap(entry -> entry.getKey().getName(),
+						SimpleImmutableEntry::getValue));
 
 		if (columnsToMigrate.isEmpty()) {
 			return null;
@@ -130,7 +130,7 @@ public class SelectiveMigratorFunction {
 							.map(entry -> entry.getValue().getName())
 							.findFirst().get();
 
-					return "\"" + mappedColumnName + "\" = r.\"" + column.getName() + "\"";
+					return mappedColumnName + " = r." + column.getName();
 				})
 				.collect(Collectors.joining(" AND "));
 
@@ -187,7 +187,7 @@ public class SelectiveMigratorFunction {
 		Map<String, String> values = columnMapping.entrySet().stream()
 				.filter(entry -> columns.contains(entry.getKey().getName()))
 				.collect(Collectors.toMap(entry -> entry.getValue().getName(),
-						entry -> "r.\"" + entry.getKey().getName() + "\"",
+						entry -> "r." + entry.getKey().getName(),
 						(u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },
 						Maps::newLinkedHashMap));
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
@@ -41,7 +41,7 @@ public class SelectiveMigratorFunction {
 	private static MigratorFunction createUpdateMigrator(RefLog refLog, Table source, Table target, Version from,
 			Version to, long batchSize, Stage stage, Set<String> columnsToBeMigrated) {
 
-		List<Column> identityColumns = source.getIdentityColumns();
+		List<Column> identityColumns = source.getPrimaryKeyColumns();
 		Map<String, String> functionParameterMapping = Maps.newHashMap();
 		for (int i = 0; i < identityColumns.size(); i++) {
 			functionParameterMapping.put(identityColumns.get(i).getName(), "q" + i);
@@ -123,7 +123,7 @@ public class SelectiveMigratorFunction {
 				})
 				.collect(Collectors.joining(", "));
 
-		String identityCondition = source.getIdentityColumns().stream()
+		String identityCondition = source.getPrimaryKeyColumns().stream()
 				.map(column -> {
 					String mappedColumnName = columnMapping.entrySet().stream()
 							.filter(entry -> entry.getKey().getName().equals(column.getName()))
@@ -166,7 +166,7 @@ public class SelectiveMigratorFunction {
 	private static MigratorFunction createInsertMigrator(NullRecords nullRecords, RefLog refLog, Table source,
 			Table target, Version from, Version to, long batchSize, Stage stage, Set<String> columns) {
 
-		List<Column> identityColumns = source.getIdentityColumns();
+		List<Column> identityColumns = source.getPrimaryKeyColumns();
 		Map<String, String> functionParameterMapping = Maps.newHashMap();
 		for (int i = 0; i < identityColumns.size(); i++) {
 			functionParameterMapping.put(identityColumns.get(i).getName(), "q" + i);

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SyncFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SyncFunction.java
@@ -136,6 +136,11 @@ public class SyncFunction {
 				.append("CREATE OR REPLACE FUNCTION " + functionName + "()")
 				.append("RETURNS TRIGGER AS $$")
 				.append("BEGIN")
+				.append("  SET LOCAL quantumdb." + source.getRefId() + " = 'true';")
+				.append("  IF current_setting('quantumdb." + target.getRefId() + "', true) = 'true' THEN")
+				.append("    RETURN NEW;")
+				.append("  END IF;")
+				.append("  SET LOCAL quantumdb." + target.getRefId() + " = 'true';")
 				.append("  IF TG_OP = 'INSERT' THEN")
 				.append("    INSERT INTO " + target.getRefId())
 				.append("      (" + represent(insertExpressions, Entry::getKey, ", ") + ") VALUES")
@@ -180,7 +185,6 @@ public class SyncFunction {
 				.append("AFTER INSERT OR UPDATE OR DELETE")
 				.append("ON " + source.getRefId())
 				.append("FOR EACH ROW")
-				.append("WHEN (pg_trigger_depth() = 0)")
 				.append("EXECUTE PROCEDURE " + functionName + "();");
 	}
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SyncFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SyncFunction.java
@@ -77,8 +77,8 @@ public class SyncFunction {
 				.collect(Collectors.toMap(entry -> entry.getKey().getName(), entry -> entry.getValue().getName()));
 
 		Map<String, String> expressions = mapping.entrySet().stream()
-				.collect(Collectors.toMap(entry -> "\"" + entry.getValue() + "\"",
-						entry -> "NEW.\"" + entry.getKey() + "\"",
+				.collect(Collectors.toMap(Entry::getValue,
+						entry -> "NEW." + entry.getKey(),
 						(u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },
 						Maps::newLinkedHashMap));
 
@@ -101,7 +101,7 @@ public class SyncFunction {
 						}
 					}
 
-					expressions.put("\"" + columnName + "\"", value);
+					expressions.put(columnName, value);
 				}
 			}
 		}
@@ -111,8 +111,8 @@ public class SyncFunction {
 
 		this.updateIdentitiesForInserts = ImmutableMap.copyOf((Map<? extends String, ? extends String>)targetTable.getColumns().stream()
 				.filter(column -> reverseLookup(mapping, column.getName()).isPresent())
-				.collect(Collectors.toMap(column -> "\"" + column.getName() + "\"",
-						column -> "NEW.\"" + reverseLookup(mapping, column.getName()).get() + "\"",
+				.collect(Collectors.toMap(Column::getName,
+						column -> "NEW." + reverseLookup(mapping, column.getName()).get(),
 						(u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },
 						Maps::newLinkedHashMap)));
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SyncFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SyncFunction.java
@@ -72,7 +72,7 @@ public class SyncFunction {
 		Map<String, String> mapping = columnMapping.entrySet().stream()
 				.filter(entry -> {
 					Column column = sourceTable.getColumn(entry.getKey().getName());
-					return columnsToMigrate.contains(entry.getValue().getName()) || column.isIdentity();
+					return columnsToMigrate.contains(entry.getValue().getName()) || column.isPrimaryKey();
 				})
 				.collect(Collectors.toMap(entry -> entry.getKey().getName(), entry -> entry.getValue().getName()));
 
@@ -116,10 +116,9 @@ public class SyncFunction {
 						(u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },
 						Maps::newLinkedHashMap)));
 
-		this.updateIdentities = ImmutableMap.copyOf((Map<? extends String, ? extends String>)targetTable.getIdentityColumns().stream()
-				.filter(column -> reverseLookup(mapping, column.getName()).isPresent())
-				.collect(Collectors.toMap(column -> "\"" + column.getName() + "\"",
-						column -> "OLD.\"" + reverseLookup(mapping, column.getName()).get() + "\"",
+		this.updateIdentities = ImmutableMap.copyOf((Map<? extends String, ? extends String>)targetTable.getPrimaryKeyColumns().stream()
+				.collect(Collectors.toMap(Column::getName,
+						column -> "OLD." + reverseLookup(mapping, column.getName()).get(),
 						(u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },
 						Maps::newLinkedHashMap)));
 	}

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
@@ -11,12 +11,8 @@ import java.util.stream.Collectors;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
-import io.quantumdb.core.schema.definitions.Column;
-import io.quantumdb.core.schema.definitions.ForeignKey;
+import io.quantumdb.core.schema.definitions.*;
 import io.quantumdb.core.schema.definitions.ForeignKey.Action;
-import io.quantumdb.core.schema.definitions.Index;
-import io.quantumdb.core.schema.definitions.Sequence;
-import io.quantumdb.core.schema.definitions.Table;
 import io.quantumdb.core.utils.QueryBuilder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -93,6 +89,13 @@ public class TableCreator {
 
 		if (!primaryKeyColumns.isEmpty()) {
 			queryBuilder.append(", PRIMARY KEY(" + Joiner.on(", ").join(primaryKeyColumns) + ")");
+		}
+
+		for (Unique unique: table.getUniques()) {
+			List<String> uniqueColumns = unique.getColumns();
+			if (!uniqueColumns.isEmpty()) {
+				queryBuilder.append(", UNIQUE(" + Joiner.on(", ").join(uniqueColumns) + ")");
+			}
 		}
 
 		queryBuilder.append(")");

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
@@ -87,12 +87,12 @@ public class TableCreator {
 			columnAdded = true;
 		}
 
-		List<String> identityColumns = table.getIdentityColumns().stream()
+		List<String> primaryKeyColumns = table.getPrimaryKeyColumns().stream()
 				.map(Column::getName)
 				.collect(Collectors.toList());
 
-		if (!identityColumns.isEmpty()) {
-			queryBuilder.append(", PRIMARY KEY(" + Joiner.on(", ").join(identityColumns) + ")");
+		if (!primaryKeyColumns.isEmpty()) {
+			queryBuilder.append(", PRIMARY KEY(" + Joiner.on(", ").join(primaryKeyColumns) + ")");
 		}
 
 		queryBuilder.append(")");

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -121,7 +121,7 @@ class TableDataMigrator {
 	}
 
 	private Map<String, Object> queryHighestId(Table from) throws SQLException {
-		List<String> identityColumns = from.getIdentityColumns().stream()
+		List<String> identityColumns = from.getPrimaryKeyColumns().stream()
 				.map(Column::getName)
 				.collect(Collectors.toList());
 
@@ -221,7 +221,7 @@ class TableDataMigrator {
 		}
 
 		Map<String, Object> identity = Maps.newHashMap();
-		List<Column> identityColumns = from.getIdentityColumns();
+		List<Column> identityColumns = from.getPrimaryKeyColumns();
 		for (int i = 0; i < identityColumns.size(); i++) {
 			Column column = identityColumns.get(i);
 			String columnName = column.getName();

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -241,6 +241,7 @@ class TableDataMigrator {
 			case INTEGER:
 				return Integer.parseInt(value);
 			case NUMERIC:
+				return Double.parseDouble(value);
 			case BIGINT:
 				return Long.parseLong(value);
 			case BOOLEAN:

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -1,5 +1,6 @@
 package io.quantumdb.core.planner;
 
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -45,10 +46,10 @@ class TableDataMigrator {
 
 		Map<String, Object> highestId = queryHighestId(source);
 		if (highestId == null) {
-			log.info("Table: {} is empty -> nothing target migrate...", source.getName());
+			log.info("Table: {} is empty -> nothing to migrate...", source.getName());
 			return;
 		}
-		log.info("Migrating data in table: {} target: {}", source.getName(), target.getName());
+		log.info("Migrating data in table: {} to target: {}", source.getName(), target.getName());
 
 		MigratorFunction initialMigrator = SelectiveMigratorFunction.createMigrator(nullRecords, refLog,
 				source, target, from, to, BATCH_SIZE, Stage.INITIAL, migratedColumns, columnsToMigrate);
@@ -172,6 +173,14 @@ class TableDataMigrator {
 				right = right.toString().toLowerCase();
 			}
 
+			if (left instanceof Long) {
+				left = new BigDecimal((Long) left);
+			}
+
+			if (right instanceof Long) {
+				right = new BigDecimal((Long) right);
+			}
+
 			Comparable leftComparable = (Comparable) left;
 			Comparable rightComparable = (Comparable) right;
 
@@ -231,6 +240,7 @@ class TableDataMigrator {
 			case SMALLINT:
 			case INTEGER:
 				return Integer.parseInt(value);
+			case NUMERIC:
 			case BIGINT:
 				return Long.parseLong(value);
 			case BOOLEAN:
@@ -238,6 +248,7 @@ class TableDataMigrator {
 			case TEXT:
 			case CHAR:
 			case VARCHAR:
+			case OID:
 				return value;
 			case DATE:
 				return Date.parse(value);
@@ -245,8 +256,6 @@ class TableDataMigrator {
 				return Float.parseFloat(value);
 			case TIMESTAMP:
 				return Timestamp.parse(value);
-			case OID:
-				return value;
 			case UUID:
 			default:
 				return UUID.fromString(value);

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
@@ -37,6 +37,8 @@ public class PostgresTypes {
 				return PostgresTypes.bigint();
 			case "integer":
 				return PostgresTypes.integer();
+			case "numeric":
+				return PostgresTypes.numeric();
 			case "bool":
 			case "boolean":
 				return PostgresTypes.bool();
@@ -105,6 +107,11 @@ public class PostgresTypes {
 	public static ColumnType integer() {
 		return new ColumnType(ColumnType.Type.INTEGER, false, "integer", () -> 0,
 				(statement, position, value) -> statement.setInt(position, ((Number) value).intValue()));
+	}
+
+	public static ColumnType numeric() {
+		return new ColumnType(ColumnType.Type.NUMERIC, false, "numeric", () -> 0.00d,
+				(statement, position, value) -> statement.setDouble(position, ((Double) value)));
 	}
 	
 	public static ColumnType bigint() {

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
@@ -13,59 +13,111 @@ import lombok.NoArgsConstructor;
 public class PostgresTypes {
 
 	public static ColumnType from(String input) {
-		Pattern pattern = Pattern.compile("^(.+)\\(([0-9]+)\\)$");
-		Matcher match = pattern.matcher(input);
+		Matcher match = Pattern.compile("^(.+)\\(([0-9]+),([0-9]+)\\)$").matcher(input);
 		if (match.find()) {
 			String type = match.group(1);
-			int length = Integer.parseInt(match.group(2));
-			return from(type, length);
+			int precision = Integer.parseInt(match.group(2));
+			int scale = Integer.parseInt(match.group(3));
+			return from(type, precision, scale);
+		} else {
+			match = Pattern.compile("^(.+)\\(([0-9]+)\\)$").matcher(input);
+			if (match.find()) {
+				String type = match.group(1);
+				int length = Integer.parseInt(match.group(2));
+				return from(type, length, -1);
+			}
 		}
-		else {
-			return from(input, null);
-		}
+		return from(input, -1, -1);
+
+
 	}
 
-	public static ColumnType from(String type, Integer length) {
-		switch (type.toLowerCase()) {
-			case "oid":
-				return PostgresTypes.oid();
-			case "uuid":
-				return PostgresTypes.uuid();
-			case "smallint":
-				return PostgresTypes.smallint();
-			case "bigint":
-				return PostgresTypes.bigint();
-			case "integer":
-				return PostgresTypes.integer();
-			case "numeric":
-				return PostgresTypes.numeric();
-			case "bool":
-			case "boolean":
-				return PostgresTypes.bool();
-			case "varchar":
-			case "character varying":
-				return PostgresTypes.varchar(length);
-			case "character":
-				return PostgresTypes.chars(length);
-			case "text":
-				return PostgresTypes.text();
-			case "timestamp with time zone":
-				return PostgresTypes.timestamp(true);
-			case "timestamp":
-			case "timestamp without time zone":
-				return PostgresTypes.timestamp(false);
-			case "date":
-				return PostgresTypes.date();
-			case "double precision":
-				return PostgresTypes.floats();
-			case "real":
-				return PostgresTypes.doubles();
-			default:
-				String error = "Unsupported type: " + type;
-				if (length != null) {
+	public static ColumnType from(String type, Integer length, Integer scale) {
+		type = type.trim();
+		if (length == null || length == -1) {
+			switch (type.toLowerCase()) {
+				case "oid":
+					return PostgresTypes.oid();
+				case "uuid":
+					return PostgresTypes.uuid();
+				case "smallserial":
+				case "int2":
+				case "smallint":
+					return PostgresTypes.smallint();
+				case "bigserial":
+				case "int8":
+				case "bigint":
+					return PostgresTypes.bigint();
+				case "serial":
+				case "int":
+				case "int4":
+				case "integer":
+					return PostgresTypes.integer();
+				case "decimal":
+				case "numeric":
+					return PostgresTypes.numeric();
+				case "bool":
+				case "boolean":
+					return PostgresTypes.bool();
+				case "varchar":
+				case "character varying":
+					return PostgresTypes.varchar();
+				case "char":
+				case "character":
+					return PostgresTypes.chars(1);
+				case "text":
+					return PostgresTypes.text();
+				case "timestamp with time zone":
+					return PostgresTypes.timestamp(true);
+				case "timestamp":
+				case "timestamp without time zone":
+					return PostgresTypes.timestamp(false);
+				case "date":
+					return PostgresTypes.date();
+				case "float8":
+				case "double precision":
+					return PostgresTypes.floats();
+				case "float4":
+				case "real":
+					return PostgresTypes.doubles();
+				case "byte array":
+				case "bytea":
+					return PostgresTypes.bytea();
+				default:
+					String error = "Unsupported type: " + type;
+					throw new IllegalArgumentException(error);
+			}
+		} else if (scale == null || scale == -1) {
+			switch (type.toLowerCase()) {
+				case "decimal":
+				case "numeric":
+					return PostgresTypes.numeric(length);
+				case "varchar":
+				case "character varying":
+					return PostgresTypes.varchar(length);
+				case "char":
+				case "character":
+					return PostgresTypes.chars(length);
+				case "timestamp with time zone":
+					return PostgresTypes.timestamp(true, length);
+				case "timestamp":
+				case "timestamp without time zone":
+					return PostgresTypes.timestamp(false, length);
+				default:
+					String error = "Unsupported type: " + type;
 					error += " (length: " + length + ")";
-				}
-				throw new IllegalArgumentException(error);
+					throw new IllegalArgumentException(error);
+			}
+		} else {
+			switch (type.toLowerCase()) {
+				case "decimal":
+				case "numeric":
+					return PostgresTypes.numeric(length, scale);
+				default:
+					String error = "Unsupported type: " + type;
+					error += " (precision: " + length + ", scale: " + scale + ")";
+					throw new IllegalArgumentException(error);
+			}
 		}
 	}
 
@@ -75,12 +127,17 @@ public class PostgresTypes {
 	}
 
 	public static ColumnType uuid() {
-		return new ColumnType(ColumnType.Type.UUID, true, "uuid", () -> UUID.randomUUID(),
+		return new ColumnType(ColumnType.Type.UUID, true, "uuid", UUID::randomUUID,
 				(statement, position, value) -> statement.setObject(position, value));
 	}
 
 	public static ColumnType varchar(int length) {
 		return new ColumnType(ColumnType.Type.VARCHAR, true, "varchar(" + length + ")", () -> "",
+				(statement, position, value) -> statement.setString(position, value.toString()));
+	}
+
+	public static ColumnType varchar() {
+		return new ColumnType(ColumnType.Type.VARCHAR, true, "varchar", () -> "",
 				(statement, position, value) -> statement.setString(position, value.toString()));
 	}
 
@@ -109,6 +166,15 @@ public class PostgresTypes {
 				(statement, position, value) -> statement.setInt(position, ((Number) value).intValue()));
 	}
 
+	public static ColumnType numeric(Integer precision, Integer scale) {
+		return new ColumnType(ColumnType.Type.NUMERIC, false, "numeric(" + precision + "," + scale + ")", () -> 0.00d,
+				(statement, position, value) -> statement.setDouble(position, ((Double) value)));
+	}
+	public static ColumnType numeric(Integer precision) {
+		return new ColumnType(ColumnType.Type.NUMERIC, false, "numeric(" + precision + ")", () -> 0.00d,
+				(statement, position, value) -> statement.setDouble(position, ((Double) value)));
+	}
+
 	public static ColumnType numeric() {
 		return new ColumnType(ColumnType.Type.NUMERIC, false, "numeric", () -> 0.00d,
 				(statement, position, value) -> statement.setDouble(position, ((Double) value)));
@@ -121,6 +187,12 @@ public class PostgresTypes {
 
 	public static ColumnType timestamp(boolean withTimezone) {
 		String typeNotation = "timestamp" + (withTimezone ? " with time zone" : "");
+		return new ColumnType(ColumnType.Type.TIMESTAMP, true, typeNotation, () -> new Timestamp(new Date().getTime()),
+				(statement, position, value) -> statement.setTimestamp(position, (Timestamp) value));
+	}
+
+	public static ColumnType timestamp(boolean withTimezone, Integer length) {
+		String typeNotation = "timestamp (" + length + ")" + (withTimezone ? " with time zone" : "");
 		return new ColumnType(ColumnType.Type.TIMESTAMP, true, typeNotation, () -> new Timestamp(new Date().getTime()),
 				(statement, position, value) -> statement.setTimestamp(position, (Timestamp) value));
 	}
@@ -138,6 +210,11 @@ public class PostgresTypes {
 	public static ColumnType floats() {
 		return new ColumnType(ColumnType.Type.FLOAT, false, "double precision", () -> 0.00f,
 				(statement, position, value) -> statement.setFloat(position, (Float) value));
+	}
+
+	public static ColumnType bytea() {
+		return new ColumnType(ColumnType.Type.BYTEA, false, "bytea", () -> new byte[0],
+				(statement, position, value) -> statement.setBytes(position, (byte[]) value));
 	}
 	
 }

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
@@ -119,9 +119,15 @@ public class Backend {
 								.map(Ints::tryParse)
 								.collect(Collectors.toList());
 
-						return PostgresTypes.from(sqlType, arguments.get(0));
+						if (arguments.size() == 2) {
+							return PostgresTypes.from(sqlType, arguments.get(0), arguments.get(1));
+						} else if (arguments.size() == 1) {
+							return PostgresTypes.from(sqlType, arguments.get(0), -1);
+						} else {
+							return PostgresTypes.from(sqlType, -1, -1);
+						}
 					}
-					return PostgresTypes.from(sqlType, null);
+					return PostgresTypes.from(sqlType, -1, -1);
 				})
 				.registerTypeAdapter(ColumnType.class, (JsonSerializer<ColumnType>)
 						(element, type, context) -> new JsonPrimitive(element.getNotation()))

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
@@ -8,14 +8,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -153,10 +147,13 @@ public class Backend {
 		while (!toDo.isEmpty()) {
 			Version version = toDo.remove(0);
 			for (Entry<RefId, String> entry : tableVersions.column(version).entrySet()) {
-				TableRef tableRef = refLog.getTableRefs(version).stream()
-						.filter(ref -> ref.getName().equals(entry.getValue()) && ref.getRefId().equals(entry.getKey().getRefId()))
-						.findFirst()
-						.orElse(null);
+				TableRef tableRef = null;
+				if (version.getParent() != null) {
+					tableRef = refLog.getTableRefs(version.getParent()).stream()
+							.filter(ref -> ref.getName().equals(entry.getValue()) && ref.getRefId().equals(entry.getKey().getRefId()))
+							.findFirst()
+							.orElse(null);
+				}
 
 				if (tableRef != null) {
 					tableRef.markAsPresent(version);
@@ -168,9 +165,8 @@ public class Backend {
 										.filter(mapping -> mapping.getTarget().equals(column))
 										.map(TableColumnMapping::getSource)
 										.map(columnCache::get)
-										.filter(ref -> ref != null)
+										.filter(Objects::nonNull)
 										.collect(Collectors.toList());
-
 								return new ColumnRef(column.getColumn(), basedOn);
 							}, (l, r) -> l, LinkedHashMap::new));
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/TransactionalityTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/TransactionalityTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.integer;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.varchar;
@@ -50,11 +50,11 @@ public class TransactionalityTest {
 		Catalog catalog = new Catalog(database.getCatalogName());
 
 		Table source = new Table("source")
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table target = new Table("target")
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		catalog.addTable(source);

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.integration.multistate;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
@@ -50,7 +50,7 @@ public class MultiStateTest extends PostgresqlDatabase {
 		step0 = changelog.getRoot();
 
 		step1 = changelog.addChangeSet("step1", "Michael de Jong", "Create test table.",
-				createTable("test").with("id", bigint(), IDENTITY, AUTO_INCREMENT))
+				createTable("test").with("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT))
 				.getLastAdded();
 
 		changelog.addChangeSet("step2", "Michael de Jong", "Add name column to test table.",

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -67,38 +67,38 @@ public class AddColumnToCustomersTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -106,7 +106,7 @@ public class AddColumnToCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -129,35 +129,35 @@ public class AddColumnToCustomersTable {
 		// New tables and foreign keys.
 
 		Table newStores = new Table(refLog.getTableRef(target, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table newStaff = new Table(refLog.getTableRef(target, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table newInventory = new Table(refLog.getTableRef(target, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table newPaychecks = new Table(refLog.getTableRef(target, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers").getRefId())
-				.addColumn(new Column("id", integer(), customers.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), customers.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()))
 				.addColumn(new Column("date_of_birth", date()));
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -165,7 +165,7 @@ public class AddColumnToCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), rentals.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), rentals.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -65,38 +65,38 @@ public class AddColumnToFilmsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -104,7 +104,7 @@ public class AddColumnToFilmsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -127,17 +127,17 @@ public class AddColumnToFilmsTable {
 		// New tables and foreign keys.
 
 		Table newFilms = new Table(refLog.getTableRef(target, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("release_date", date()));
 
 		Table newInventory = new Table(refLog.getTableRef(target, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -145,7 +145,7 @@ public class AddColumnToFilmsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
@@ -66,38 +66,38 @@ public class AddColumnToPaymentsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -105,7 +105,7 @@ public class AddColumnToPaymentsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -128,7 +128,7 @@ public class AddColumnToPaymentsTable {
 		// New tables and foreign keys.
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -68,38 +68,38 @@ public class AddForeignKeyToPaymentsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -107,7 +107,7 @@ public class AddForeignKeyToPaymentsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -130,7 +130,7 @@ public class AddForeignKeyToPaymentsTable {
 		// New tables and foreign keys.
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -67,38 +67,38 @@ public class CopyCustomersTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -106,7 +106,7 @@ public class CopyCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -129,7 +129,7 @@ public class CopyCustomersTable {
 		// New tables and foreign keys.
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers_backup").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -51,7 +51,7 @@ public class CreateCreditCardsTable {
 
 		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.createTable("credit_cards")
-						.with("credit_card_number", varchar(255), IDENTITY, NOT_NULL)
+						.with("credit_card_number", varchar(255), PRIMARY_KEY, NOT_NULL)
 						.with("card_holder_name", varchar(255), NOT_NULL)
 						.with("expiration_date", date(), NOT_NULL));
 
@@ -70,38 +70,38 @@ public class CreateCreditCardsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -109,7 +109,7 @@ public class CreateCreditCardsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -132,7 +132,7 @@ public class CreateCreditCardsTable {
 		// New tables and foreign keys.
 
 		Table creditCards = new Table(refLog.getTableRef(target, "credit_cards").getRefId())
-				.addColumn(new Column("credit_card_number", varchar(255), IDENTITY, NOT_NULL))
+				.addColumn(new Column("credit_card_number", varchar(255), PRIMARY_KEY, NOT_NULL))
 				.addColumn(new Column("card_holder_name", varchar(255), NOT_NULL))
 				.addColumn(new Column("expiration_date", date(), NOT_NULL));
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -65,38 +65,38 @@ public class DropColumnFromCustomersTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -104,7 +104,7 @@ public class DropColumnFromCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -127,12 +127,12 @@ public class DropColumnFromCustomersTable {
 		// New tables and foreign keys.
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -140,7 +140,7 @@ public class DropColumnFromCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -67,38 +67,38 @@ public class DropForeignKeyFromCustomersTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -106,7 +106,7 @@ public class DropForeignKeyFromCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -129,7 +129,7 @@ public class DropForeignKeyFromCustomersTable {
 		// New tables and foreign keys.
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -137,14 +137,14 @@ public class DropForeignKeyFromCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL));
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
@@ -8,7 +8,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -64,38 +64,38 @@ public class DropPaymentsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -103,7 +103,7 @@ public class DropPaymentsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.integration.videostores;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -63,38 +63,38 @@ public class MakeStoreFieldInStaffTableNullable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -102,7 +102,7 @@ public class MakeStoreFieldInStaffTableNullable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -125,34 +125,34 @@ public class MakeStoreFieldInStaffTableNullable {
 		// New tables and foreign keys.
 
 		Table newStores = new Table(refLog.getTableRef(target, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table newStaff = new Table(refLog.getTableRef(target, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer()));
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table newInventory = new Table(refLog.getTableRef(target, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table newPaychecks = new Table(refLog.getTableRef(target, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -160,7 +160,7 @@ public class MakeStoreFieldInStaffTableNullable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.doubles;
@@ -67,38 +67,38 @@ public class ModifyTypeInPaymentsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -106,7 +106,7 @@ public class ModifyTypeInPaymentsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -129,7 +129,7 @@ public class ModifyTypeInPaymentsTable {
 		// New tables and foreign keys.
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/PostgresqlBaseScenario.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/PostgresqlBaseScenario.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.integration.videostores;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -59,38 +59,38 @@ public class PostgresqlBaseScenario extends PostgresqlDatabase {
 		TableCreator tableCreator = new TableCreator();
 
 		Table stores = new Table(STORES_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(STAFF_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(CUSTOMERS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(FILMS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(INVENTORY_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(PAYCHECKS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(PAYMENTS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -98,7 +98,7 @@ public class PostgresqlBaseScenario extends PostgresqlDatabase {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(RENTALS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -66,38 +66,38 @@ public class RenameCustomersTable {
 		RefLog refLog = state.getRefLog();
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -105,7 +105,7 @@ public class RenameCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/GreedyMigrationPlannerTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/GreedyMigrationPlannerTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.planner;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
@@ -86,7 +86,7 @@ public class GreedyMigrationPlannerTest {
 			Catalog catalog = new Catalog("fullMagnet");
 
 			Table answeredQuestions = new Table("answered_questions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("jobseeker_id", bigint()))
 					.addColumn(new Column("is_positive", bool(), NOT_NULL))
@@ -95,10 +95,10 @@ public class GreedyMigrationPlannerTest {
 
 			Table applicationAttachments = new Table("application_attachments")
 					.addColumn(new Column("application_id", bigint(), NOT_NULL))
-					.addColumn(new Column("attachment_id", bigint(), NOT_NULL, IDENTITY));
+					.addColumn(new Column("attachment_id", bigint(), NOT_NULL, PRIMARY_KEY));
 
 			Table applications = new Table("applications")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL))
 					.addColumn(new Column("opportunity_id", bigint(), NOT_NULL))
@@ -108,14 +108,14 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table applicationsResponses = new Table("applications__responses")
-					.addColumn(new Column("application_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("application_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("message", text()))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table cloudImages = new Table("cloud_images")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("bucket", varchar(255), NOT_NULL))
 					.addColumn(new Column("folder", varchar(255)))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
@@ -124,12 +124,12 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table companies = new Table("companies")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("employees", integer()));
 
 			Table conversationSubscribers = new Table("conversation_subscribers")
-					.addColumn(new Column("conversation_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("subscriber_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("conversation_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("subscriber_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("starred", bool(), "'false'", NOT_NULL))
 					.addColumn(new Column("archived", bool(), "'false'", NOT_NULL))
 					.addColumn(new Column("last_read_message_id", bigint()))
@@ -137,7 +137,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table conversations = new Table("conversations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("title", varchar(255), NOT_NULL))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("sender_id", bigint(), NOT_NULL))
@@ -146,7 +146,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table databasechangelog = new Table("databasechangelog")
-					.addColumn(new Column("id", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("author", varchar(255), NOT_NULL))
 					.addColumn(new Column("filename", varchar(255), NOT_NULL))
 					.addColumn(new Column("dateexecuted", timestamp(true), NOT_NULL))
@@ -159,26 +159,26 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("liquibase", varchar(255)));
 
 			Table databasechangeloglock = new Table("databasechangeloglock")
-					.addColumn(new Column("id", integer(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", integer(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("locked", bool(), NOT_NULL))
 					.addColumn(new Column("lockgranted", timestamp(true)))
 					.addColumn(new Column("lockedby", varchar(255)));
 
 			Table deletedUsers = new Table("deleted_users")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("email", varchar(255), NOT_NULL))
 					.addColumn(new Column("deleted_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("found_job_via_magnet", bool()))
 					.addColumn(new Column("invalid_email", bool(), "'false'", NOT_NULL));
 
 			Table educationNames = new Table("education_names")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table educations = new Table("educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("institution_id", bigint(), NOT_NULL))
 					.addColumn(new Column("education_name_id", bigint(), NOT_NULL))
 					.addColumn(new Column("level", varchar(255), NOT_NULL))
@@ -188,12 +188,12 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table emailOptOut = new Table("email_opt_out")
-					.addColumn(new Column("email", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("email", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table employeesPerCountry = new Table("employees_per_country")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("country", varchar(255), NOT_NULL))
 					.addColumn(new Column("number_of_employees", integer(), NOT_NULL))
 					.addColumn(new Column("company_id", bigint(), NOT_NULL))
@@ -201,26 +201,26 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table eventOrganizers = new Table("event_organizers")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT));
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT));
 
 			Table experiences = new Table("experiences")
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("hours_per_week_spent", integer()))
 					.addColumn(new Column("weeks_spent", integer(), NOT_NULL))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("institute_name", varchar(255)))
 					.addColumn(new Column("country", varchar(255)))
 					.addColumn(new Column("city", varchar(255)));
 
 			Table extraCurricularExperiences = new Table("extra_curricular_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("volunteer", bool(), "'false'", NOT_NULL))
 					.addColumn(new Column("work_type", varchar(255)))
 					.addColumn(new Column("second_work_type", varchar(255)));
 
 			Table featureFlags = new Table("feature_flags")
-					.addColumn(new Column("user_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("feature", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("user_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("feature", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
@@ -231,12 +231,12 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("created_by_user_id", bigint(), NOT_NULL))
 					.addColumn(new Column("created", timestamp(true), NOT_NULL))
 					.addColumn(new Column("name", varchar(255)))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table institutions = new Table("institutions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("url", varchar(255)))
 					.addColumn(new Column("verified", bool(), "'false'", NOT_NULL))
@@ -247,7 +247,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table invites = new Table("invites")
-					.addColumn(new Column("id", uuid(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", uuid(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("email", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("invited_by", bigint()))
@@ -257,7 +257,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table jobSeekerEmailPreferences = new Table("job_seeker_email_preferences")
-					.addColumn(new Column("user_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("user_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("personal_messages", bool(), "'true'", NOT_NULL))
 					.addColumn(new Column("application_response", bool(), "'true'", NOT_NULL))
 					.addColumn(new Column("network_requests", varchar(255), "''IMMEDIATELY'::character varying'", NOT_NULL))
@@ -271,7 +271,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("last_profile_view_sent_at", timestamp(true)));
 
 			Table jobseekersSavedOpportunities = new Table("jobseekers__saved_opportunities")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("jobseeker_id", bigint()))
 					.addColumn(new Column("opportunity_id", bigint()))
 					.addColumn(new Column("saved_at", timestamp(true), "'now()'", NOT_NULL))
@@ -280,7 +280,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("opportunity_name", varchar(255)));
 
 			Table languageSkills = new Table("language_skills")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("level", varchar(255), NOT_NULL))
 					.addColumn(new Column("language", varchar(255), NOT_NULL))
@@ -288,7 +288,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table magnetTransactions = new Table("magnet_transactions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("date", timestamp(true), NOT_NULL))
 					.addColumn(new Column("delta", integer(), NOT_NULL))
@@ -304,7 +304,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("invited_user_id", bigint()));
 
 			Table messages = new Table("messages")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("body", text(), NOT_NULL))
 					.addColumn(new Column("sender_id", bigint(), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
@@ -312,11 +312,11 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table networkOpportunities = new Table("network_opportunities")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("opportunity_id", bigint(), NOT_NULL, IDENTITY));
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("opportunity_id", bigint(), NOT_NULL, PRIMARY_KEY));
 
 			Table networks = new Table("networks")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("active", bool(), "'true'", NOT_NULL))
@@ -342,12 +342,12 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("master_edu_weight", varchar(255)));
 
 			Table networksRecruiters = new Table("networks__recruiters")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("update_subscription", varchar(255), "''IMMEDIATELY'::character varying'", NOT_NULL));
 
 			Table newsPosts = new Table("news_posts")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("type", varchar(255), NOT_NULL))
 					.addColumn(new Column("body", text(), NOT_NULL))
 					.addColumn(new Column("poster_id", bigint(), NOT_NULL))
@@ -359,11 +359,11 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table newsPostsNetworks = new Table("news_posts__networks")
-					.addColumn(new Column("news_post_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY));
+					.addColumn(new Column("news_post_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY));
 
 			Table occupations = new Table("occupations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("started", date(), NOT_NULL))
 					.addColumn(new Column("finished", date()))
@@ -374,7 +374,7 @@ public class GreedyMigrationPlannerTest {
 
 			Table opportunities = new Table("opportunities")
 					.addColumn(new Column("type", varchar(255), NOT_NULL))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
@@ -402,8 +402,8 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("end_time", timestamp(true)));
 
 			Table organizationPages = new Table("organization_pages")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("organization_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("organization_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("heading", varchar(255), NOT_NULL))
 					.addColumn(new Column("text", text()))
 					.addColumn(new Column("image_id", bigint()))
@@ -416,7 +416,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table organizationTags = new Table("organization_tags")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("organization_id", bigint()))
 					.addColumn(new Column("color", chars(255)))
@@ -425,7 +425,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("last_used", timestamp(true), "'now()'", NOT_NULL));
 
 			Table organizations = new Table("organizations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("active", bool(), "'false'", NOT_NULL))
 					.addColumn(new Column("name", varchar(255)))
 					.addColumn(new Column("phone_number", varchar(255)))
@@ -454,11 +454,11 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("questionnaire_priority", integer()));
 
 			Table pepCountries = new Table("pep_countries")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("country", varchar(255), NOT_NULL));
 
 			Table pepExperienceIndustries = new Table("pep_experience_industries")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("experience_id", bigint(), NOT_NULL))
 					.addColumn(new Column("industry", varchar(255), NOT_NULL))
 					.addColumn(new Column("weight", varchar(255)))
@@ -466,21 +466,21 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepExperienceWorkTypes = new Table("pep_experience_work_types")
-					.addColumn(new Column("experience_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("work_type", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("experience_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("work_type", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("weight", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterAbroad = new Table("pep_filter_abroad")
-					.addColumn(new Column("experience_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("type", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("experience_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("type", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("weight", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducations = new Table("pep_filter_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
 					.addColumn(new Column("reject_policy", varchar(255), NOT_NULL))
 					.addColumn(new Column("type", varchar(255), NOT_NULL))
@@ -500,21 +500,21 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsHasSelectedDisciplines = new Table("pep_filter_educations__has_selected_disciplines")
-					.addColumn(new Column("pep_filter_education_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("pep_filter_education_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("selected_discipline", varchar(255)))
 					.addColumn(new Column("weight", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsHasSelectedSubdisciplines = new Table("pep_filter_educations__has_selected_subdisciplines")
-					.addColumn(new Column("pep_filter_education_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("pep_filter_education_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("selected_subdiscipline", varchar(255), NOT_NULL))
 					.addColumn(new Column("weight", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsSelectedEducationNames = new Table("pep_filter_educations__selected_education_names")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("pep_filter_education_id", bigint()))
 					.addColumn(new Column("included", bool(), NOT_NULL))
 					.addColumn(new Column("education_name_id", bigint()))
@@ -522,7 +522,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsSelectedEducations = new Table("pep_filter_educations__selected_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("pep_filter_education_id", bigint()))
 					.addColumn(new Column("included", bool(), NOT_NULL))
 					.addColumn(new Column("education_id", bigint()))
@@ -530,7 +530,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsSelectedInstitutions = new Table("pep_filter_educations__selected_institutions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("pep_filter_education_id", bigint()))
 					.addColumn(new Column("included", bool(), NOT_NULL))
 					.addColumn(new Column("institution_id", bigint()))
@@ -538,7 +538,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterExperiences = new Table("pep_filter_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
 					.addColumn(new Column("reject_policy", varchar(255), NOT_NULL))
 					.addColumn(new Column("network_id", bigint()))
@@ -549,7 +549,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterLanguages = new Table("pep_filter_languages")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
 					.addColumn(new Column("reject_policy", varchar(255), NOT_NULL))
 					.addColumn(new Column("network_id", bigint()))
@@ -559,7 +559,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterTools = new Table("pep_filter_tools")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
 					.addColumn(new Column("reject_policy", varchar(255), NOT_NULL))
 					.addColumn(new Column("network_id", bigint()))
@@ -569,7 +569,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterTravels = new Table("pep_filter_travels")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("network_id", bigint()))
 					.addColumn(new Column("minimum_months", integer(), NOT_NULL))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
@@ -578,19 +578,19 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepJobLevels = new Table("pep_job_levels")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("job_level", varchar(255), NOT_NULL, IDENTITY));
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("job_level", varchar(255), NOT_NULL, PRIMARY_KEY));
 
 			Table pepJobtypes = new Table("pep_jobtypes")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("jobtype", varchar(255), NOT_NULL, IDENTITY));
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("jobtype", varchar(255), NOT_NULL, PRIMARY_KEY));
 
 			Table pepStudyPhases = new Table("pep_study_phases")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("study_phase", varchar(255), NOT_NULL, IDENTITY));
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("study_phase", varchar(255), NOT_NULL, PRIMARY_KEY));
 
 			Table pepUpdateRequests = new Table("pep_update_requests")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("type", varchar(255), NOT_NULL))
 					.addColumn(new Column("work_started_at", timestamp(true)))
 					.addColumn(new Column("work_started_by", varchar(255)))
@@ -605,20 +605,20 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepWorkTypes = new Table("pep_work_types")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("work_type", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table premiumRenewals = new Table("premium_renewals")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("start_date", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("invite_id", uuid()))
 					.addColumn(new Column("days", integer(), NOT_NULL));
 
 			Table profileViews = new Table("profile_views")
-					.addColumn(new Column("id", bigint(), "'nextval('profile_views_id_seq1'::regclass)'", NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), "'nextval('profile_views_id_seq1'::regclass)'", NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("recruiter_id", bigint()))
 					.addColumn(new Column("date", date(), "'now()'", NOT_NULL))
@@ -627,7 +627,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("mailed", bool(), "'false'", NOT_NULL));
 
 			Table purchases = new Table("purchases")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("key", varchar(255), NOT_NULL))
 					.addColumn(new Column("permission_value", integer()))
@@ -635,11 +635,11 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table queuedMailTags = new Table("queued_mail_tags")
-					.addColumn(new Column("mail_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("mail_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("tag", varchar(255)));
 
 			Table queuedMails = new Table("queued_mails")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("delivery_time", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("to_name", varchar(255)))
@@ -656,7 +656,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("track_id", varchar(255)));
 
 			Table recruiterEmailPreferences = new Table("recruiter_email_preferences")
-					.addColumn(new Column("user_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("user_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("personal_messages", bool(), "'true'", NOT_NULL))
 					.addColumn(new Column("application", varchar(255), "''IMMEDIATELY'::character varying'", NOT_NULL))
 					.addColumn(new Column("bounce_problems", timestamp(true)))
@@ -665,80 +665,80 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table recruiters = new Table("recruiters")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("role", text()))
 					.addColumn(new Column("visibility", varchar(255), "''NETWORK'::character varying'", NOT_NULL))
 					.addColumn(new Column("timeline_feed_intro_seen", bool(), "'false'"));
 
 			Table scheduledNetworkRequestEmails = new Table("scheduled_network_request_emails")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("scheduled", timestamp(true), NOT_NULL))
 					.addColumn(new Column("deliver_at", timestamp(true), NOT_NULL))
 					.addColumn(new Column("sent_at", timestamp(true)))
 					.addColumn(new Column("requests_sent", integer()));
 
 			Table scheduledNewInNetworkEmails = new Table("scheduled_new_in_network_emails")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("scheduled", timestamp(true), NOT_NULL))
 					.addColumn(new Column("deliver_at", timestamp(true), NOT_NULL))
 					.addColumn(new Column("sent_at", timestamp(true)))
 					.addColumn(new Column("job_seekers_sent", integer()));
 
 			Table scheduledOnboardingEmails = new Table("scheduled_onboarding_emails")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("jobseeker_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("jobseeker_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("scheduled", timestamp(true), NOT_NULL))
 					.addColumn(new Column("deliver_at", timestamp(true), NOT_NULL))
 					.addColumn(new Column("sent_at", timestamp(true)));
 
 			Table scheduledQuestions = new Table("scheduled_questions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("jobseeker_id", bigint(), NOT_NULL))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("saved_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("is_positive", bool(), NOT_NULL));
 
 			Table sportExperiences = new Table("sport_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY));
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY));
 
 			Table studentCompanySizeInterests = new Table("student_company_size_interests")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("company_size", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentHighSchools = new Table("student_high_schools")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("level", varchar(255)))
 					.addColumn(new Column("school_name", varchar(255)))
 					.addColumn(new Column("city", varchar(255), NOT_NULL))
 					.addColumn(new Column("country", varchar(255), NOT_NULL));
 
 			Table studentHigherEducations = new Table("student_higher_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("aborted", bool(), "'false'"))
 					.addColumn(new Column("education_id", bigint()))
 					.addColumn(new Column("nominal_duration", integer(), NOT_NULL));
 
 			Table studentInterestedIndustries = new Table("student_interested_industries")
-					.addColumn(new Column("student_id", bigint(), IDENTITY))
+					.addColumn(new Column("student_id", bigint(), PRIMARY_KEY))
 					.addColumn(new Column("industries", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentInterestedWorkTypes = new Table("student_interested_work_types")
-					.addColumn(new Column("student_id", bigint(), IDENTITY))
+					.addColumn(new Column("student_id", bigint(), PRIMARY_KEY))
 					.addColumn(new Column("types_of_work", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentOtherEducations = new Table("student_other_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("institute", varchar(255)))
 					.addColumn(new Column("migrate_suggestion", varchar(255)))
@@ -748,7 +748,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table students = new Table("students")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("date_of_birth", date()))
 					.addColumn(new Column("invited_by", bigint()))
 					.addColumn(new Column("status", varchar(255)))
@@ -773,12 +773,12 @@ public class GreedyMigrationPlannerTest {
 
 			Table studentsEducations = new Table("students__educations")
 					.addColumn(new Column("gpa", floats()))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("graduated", bool()));
 
 			Table studentsNetworks = new Table("students__networks")
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("status", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("updated_at", timestamp(true), "'now()'", NOT_NULL))
@@ -788,30 +788,30 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("responded_at", timestamp(true)));
 
 			Table studentsOrganizationsTags = new Table("students__organizations__tags")
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("tag_id", bigint()));
 
 			Table studentsPhotos = new Table("students__photos")
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("cloud_image_id", bigint(), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentsUploads = new Table("students__uploads")
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
-					.addColumn(new Column("attachment_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("attachment_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table subscriptionsPermissions = new Table("subscriptions__permissions")
-					.addColumn(new Column("subscription", varchar(255), NOT_NULL, IDENTITY))
-					.addColumn(new Column("key", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("subscription", varchar(255), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("key", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("permission_value", integer()))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table toolSkills = new Table("tool_skills")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("level", varchar(255), NOT_NULL))
 					.addColumn(new Column("tool_id", bigint()))
@@ -819,13 +819,13 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table tools = new Table("tools")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table travelExperiences = new Table("travel_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("summary", varchar(255), NOT_NULL))
 					.addColumn(new Column("location", varchar(255), NOT_NULL))
@@ -836,7 +836,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table users = new Table("users")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("email", varchar(255), NOT_NULL))
 					.addColumn(new Column("first_name", varchar(255), NOT_NULL))
 					.addColumn(new Column("last_name", varchar(255), NOT_NULL))
@@ -870,7 +870,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table workExperiences = new Table("work_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("role", varchar(255)))
 					.addColumn(new Column("industry", varchar(255), "''OTHER'::character varying'"))
 					.addColumn(new Column("internship", bool(), "'false'", NOT_NULL))
@@ -879,7 +879,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("second_work_type", varchar(255)));
 
 			Table youtubeVideos = new Table("youtube_videos")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("video_id", varchar(255)))
 					.addColumn(new Column("title", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
@@ -1113,13 +1113,13 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("hours_per_week_spent", integer()))
 					.addColumn(new Column("weeks_spent", integer(), NOT_NULL))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("institute_name", varchar(255)))
 					.addColumn(new Column("country", varchar(255)))
 					.addColumn(new Column("city", varchar(255)));
 
 			Table occupations = new Table("occupations")
-					.addColumn(new Column("id", bigint(), AUTO_INCREMENT, NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), AUTO_INCREMENT, NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("started", date(), NOT_NULL))
 					.addColumn(new Column("abroad", bool(), "'false'", NOT_NULL))
@@ -1127,26 +1127,26 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentHighSchools = new Table("student_high_schools")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("level", varchar(255)))
 					.addColumn(new Column("school_name", varchar(255)))
 					.addColumn(new Column("city", varchar(255), NOT_NULL))
 					.addColumn(new Column("country", varchar(255), NOT_NULL));
 
 			Table studentHigherEducations = new Table("student_higher_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("aborted", bool(), "'false'"))
 					.addColumn(new Column("education_id", bigint()))
 					.addColumn(new Column("nominal_duration", integer(), NOT_NULL));
 
 			Table studentInterestedIndustries = new Table("student_interested_industries")
-					.addColumn(new Column("student_id", bigint(), IDENTITY))
+					.addColumn(new Column("student_id", bigint(), PRIMARY_KEY))
 					.addColumn(new Column("industries", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table students = new Table("students")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("invited_by", bigint()))
 					.addColumn(new Column("magnets", integer(), "'0'", NOT_NULL))
 					.addColumn(new Column("main_experience_id", bigint()))
@@ -1156,11 +1156,11 @@ public class GreedyMigrationPlannerTest {
 
 			Table studentsEducations = new Table("students__educations")
 					.addColumn(new Column("gpa", floats()))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("graduated", bool()));
 
 			Table users = new Table("users")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("email", varchar(255), NOT_NULL))
 					.addColumn(new Column("first_name", varchar(255), NOT_NULL))
 					.addColumn(new Column("last_name", varchar(255), NOT_NULL))
@@ -1197,50 +1197,50 @@ public class GreedyMigrationPlannerTest {
 			Catalog catalog = new Catalog("test-db");
 
 			Table stores = new Table("stores")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 			Table staff = new Table("staff")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 			Table customers = new Table("customers")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("store_id", integer(), NOT_NULL))
 					.addColumn(new Column("referred_by", integer()));
 
 			Table films = new Table("films")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 			Table inventory = new Table("inventory")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("store_id", integer(), NOT_NULL))
 					.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 			Table paychecks = new Table("paychecks")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("staff_id", integer(), NOT_NULL))
-					.addColumn(new Column("date", date(), IDENTITY, NOT_NULL))
+					.addColumn(new Column("date", date(), PRIMARY_KEY, NOT_NULL))
 					.addColumn(new Column("amount", floats(), NOT_NULL));
 
 			Table payments = new Table("payments")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("staff_id", integer()))
 					.addColumn(new Column("customer_id", integer(), NOT_NULL))
 					.addColumn(new Column("rental_id", integer(), NOT_NULL))
-					.addColumn(new Column("date", date(), IDENTITY, NOT_NULL))
+					.addColumn(new Column("date", date(), PRIMARY_KEY, NOT_NULL))
 					.addColumn(new Column("amount", floats(), NOT_NULL));
 
 			Table rentals = new Table("rentals")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("staff_id", integer()))
 					.addColumn(new Column("customer_id", integer(), NOT_NULL))
 					.addColumn(new Column("inventory_id", integer(), NOT_NULL))
-					.addColumn(new Column("date", date(), IDENTITY, NOT_NULL));
+					.addColumn(new Column("date", date(), PRIMARY_KEY, NOT_NULL));
 
 			stores.addForeignKey("manager_id").referencing(staff, "id");
 
@@ -1280,29 +1280,29 @@ public class GreedyMigrationPlannerTest {
 			Catalog catalog = new Catalog("test-db");
 
 			Table users = new Table("users")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 			Table students = new Table("students")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("referred_by", integer()))
 					.addColumn(new Column("main_student_higher_education", integer()))
 					.addColumn(new Column("main_experience", integer()));
 
 			Table studentHigherEducations = new Table("student_higher_educations")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("student_education_id", integer(), NOT_NULL));
 
 			Table studentEducations = new Table("student_educations")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("resume_id", integer(), NOT_NULL));
 
 			Table experiences = new Table("experiences")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("resume_id", integer(), NOT_NULL));
 
 			Table resumes = new Table("resumes")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("student_id", integer(), NOT_NULL));
 
 			students.addForeignKey("id").referencing(users, "id");
@@ -1443,7 +1443,7 @@ public class GreedyMigrationPlannerTest {
 
 			Table table = operation.getTables().iterator().next();
 
-			List<Column> identityColumns = table.getIdentityColumns();
+			List<Column> identityColumns = table.getPrimaryKeyColumns();
 			Set<Column> columns = operation.getColumns().stream()
 					.map(table::getColumn)
 					.collect(Collectors.toSet());

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/SyncFunctionTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/SyncFunctionTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.planner;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.varchar;
@@ -35,11 +35,11 @@ public class SyncFunctionTest {
 	@Test
 	public void testSimpleDataMapping() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("email", varchar(255)));
 
@@ -68,19 +68,19 @@ public class SyncFunctionTest {
 		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("id", "name", "email"));
 
-		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("\"id\"", "OLD.\"id\"")));
+		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("id", "NEW.id", "name", "NEW.name")));
+		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("id", "NEW.id", "name", "NEW.name")));
+		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("id", "OLD.id")));
 	}
 
 	@Test
 	public void testDataMappingWithColumnRename() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("full_name", varchar(255), NOT_NULL));
 
 		Catalog catalog = new Catalog("public");
@@ -108,19 +108,19 @@ public class SyncFunctionTest {
 		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("id", "full_name"));
 
-		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"full_name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"full_name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("\"id\"", "OLD.\"id\"")));
+		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("id", "NEW.id", "full_name", "NEW.name")));
+		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("id", "NEW.id", "full_name", "NEW.name")));
+		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("id", "OLD.id")));
 	}
 
 	@Test
 	public void testDataMappingWithColumnIdentityRename() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("user_id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("user_id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Catalog catalog = new Catalog("public");
@@ -148,19 +148,19 @@ public class SyncFunctionTest {
 		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("user_id", "name"));
 
-		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"user_id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("\"user_id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("\"user_id\"", "OLD.\"id\"")));
+		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("user_id", "NEW.id", "name", "NEW.name")));
+		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("user_id", "NEW.id", "name", "NEW.name")));
+		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("user_id", "OLD.id")));
 	}
 
 	@Test
 	public void testDataMappingWhereColumnIsMadeNonNullable() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255)));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Catalog catalog = new Catalog("public");
@@ -186,24 +186,24 @@ public class SyncFunctionTest {
 		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("id", "name"));
 
-		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("\"id\"", "OLD.\"id\"")));
+		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("id", "NEW.id", "name", "NEW.name")));
+		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("id", "NEW.id", "name", "NEW.name")));
+		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("id", "OLD.id")));
 	}
 
 	@Test
 	public void testDataMappingWithNonNullableForeignKey() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("other_id", bigint(), NOT_NULL))
 				.addColumn(new Column("name", varchar(255)));
 
 		Table other = new Table("other")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255)));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("other_id", bigint(), NOT_NULL))
 				.addColumn(new Column("full_name", varchar(255), NOT_NULL));
 
@@ -239,9 +239,9 @@ public class SyncFunctionTest {
 		SyncFunction syncFunction = new SyncFunction(refLog, source, target, columnMapping, catalog, nullRecords);
 		syncFunction.setColumnsToMigrate(list("id", "full_name"));
 
-		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"other_id\"", "0", "\"full_name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("\"id\"", "NEW.\"id\"", "\"other_id\"", "0", "\"full_name\"", "NEW.\"name\"")));
-		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("\"id\"", "OLD.\"id\"")));
+		assertThat(syncFunction.getInsertExpressions(), is(ImmutableMap.of("id", "NEW.id", "other_id", "0", "full_name", "NEW.name")));
+		assertThat(syncFunction.getUpdateExpressions(), is(ImmutableMap.of("id", "NEW.id", "other_id", "0", "full_name", "NEW.name")));
+		assertThat(syncFunction.getUpdateIdentities(), is(ImmutableMap.of("id", "OLD.id")));
 	}
 
 	private Set<String> list(String... inputs) {

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/versioning/BackendTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/versioning/BackendTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.versioning;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
@@ -46,10 +46,10 @@ public class BackendTest {
 		Catalog catalog = new Catalog("public")
 				.addSequence(sequence)
 				.addTable(new Table("table_1")
-						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, IDENTITY))
+						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, PRIMARY_KEY))
 						.addColumn(new Column("name", text(), NOT_NULL)))
 				.addTable(new Table("table_2")
-						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, IDENTITY))
+						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, PRIMARY_KEY))
 						.addColumn(new Column("name", text(), NOT_NULL))
 						.addColumn(new Column("admin", bool(), "false", NOT_NULL)));
 

--- a/quantumdb-query-rewriter/pom.xml
+++ b/quantumdb-query-rewriter/pom.xml
@@ -2,15 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<parent>
-		<artifactId>quantumdb</artifactId>
-		<groupId>io.quantumdb</groupId>
-		<version>0.4.1-SNAPSHOT</version>
-	</parent>
-	<modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>quantumdb</artifactId>
+        <groupId>io.quantumdb</groupId>
+        <version>0.4.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>${parent.groupId}</groupId>
-	<artifactId>quantumdb-query-rewriter</artifactId>
-	<version>${parent.version}</version>
+    <artifactId>quantumdb-query-rewriter</artifactId>
+    <!--	<version>${project.version}</version>-->
 
 </project>


### PR DESCRIPTION
With this pull request I want to incorporate some fixes I made when testing the application.

I also updated the dependencies (except for jline, the new versions did not support some functionality) and everything still seems to be working correctly.

The drop functionality did not work as expected and therefore I remade the logic for that.

The RefLog was also not loaded correctly as it did not request a versions parent but itself, this made it so that no table was based on a table from another version.

I also redesigned the cascading trigger functionality. I tested more than 2 active versions and it did not update version 3 (or 4 for that matter) of a table as the trigger triggering version 2 could not trigger the one going to version 3. (V1 <-> V2 <-> V3 <-> V4 ...)
The way it now works is by exploiting runtime parameters which can be changed locally within a transaction. It now checks if the table that is being written into was already written into in this transaction. This also prevents the endless loop for which pg_trigger_depth() = 0 was used.

I will continue improving and testing QuantumDB. I still have an error with a loop within the RefLog object with a very specific changeset where I change multiple tables twice.

I also have another functionality in mind that returns all tables to their original names with a specific command. This way if someone decides to not use QuantumDB anymore he or she does not have to use the query rewriter anymore.
