### PR TITLE
Ensure we can init a database with tables/columns containing uppercase characters.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.4</version>
+			<version>1.18.20</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
@@ -144,7 +144,7 @@ class CatalogLoader {
 				.append("FROM pg_index, pg_class, pg_attribute, pg_namespace ")
 				.append("WHERE ")
 				.append("  nspname = 'public' AND ")
-				.append("  pg_class.oid = '" + tableName + "'::regclass AND ")
+				.append("  pg_class.oid = '\"" + tableName + "\"'::regclass AND ")
 				.append("  indrelid = pg_class.oid AND ")
 				.append("  pg_class.relnamespace = pg_namespace.oid AND ")
 				.append("  pg_attribute.attrelid = pg_class.oid AND ")
@@ -283,6 +283,7 @@ class CatalogLoader {
 				parser.expect("INDEX");
 				parser.present("CONCURRENTLY");
 				String indexName = parser.consume();
+				indexName = removeOuterQuotes(indexName);
 				if (indexName.startsWith("pk_")) {
 					continue;
 				}
@@ -292,6 +293,10 @@ class CatalogLoader {
 				if (indexTableName.startsWith("public.")) {
 					indexTableName = indexTableName.substring("public.".length());
 				}
+				else if (indexTableName.startsWith("\"public\".")) {
+					indexTableName = indexTableName.substring("\"public\".".length());
+				}
+				indexTableName = removeOuterQuotes(indexTableName);
 
 				if (parser.present("USING")) {
 					parser.consume();
@@ -305,4 +310,16 @@ class CatalogLoader {
 			}
 		}
 	}
+
+	private static String removeOuterQuotes(String input) {
+		if (input != null && input.length() >= 2) {
+			int head = 0;
+			int tail = input.length() - 1;
+			if (input.charAt(head) == '\"' && input.charAt(tail) == '\"') {
+				return input.substring(head + 1, tail);
+			}
+		}
+		return input;
+	}
+
 }

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/CatalogLoaderTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/CatalogLoaderTest.java
@@ -1,0 +1,37 @@
+package io.quantumdb.core.planner;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import io.quantumdb.core.backends.PostgresqlDatabase;
+import io.quantumdb.core.schema.definitions.Catalog;
+import io.quantumdb.core.schema.definitions.Table;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CatalogLoaderTest {
+
+	@Rule
+	public final PostgresqlDatabase database = new PostgresqlDatabase();
+
+	@Test
+	public void ensureWeCanLoadCatalogWithUppercaseCharactersInTablesAndColumns() throws SQLException {
+		try (Connection connection = database.createConnection()) {
+			try (Statement statement = connection.createStatement()) {
+				statement.execute("CREATE TABLE \"Users\" (\"Id\" bigint, \"FirstName\" text, PRIMARY KEY (\"Id\"));");
+			}
+		}
+
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = CatalogLoader.load(connection, database.getCatalogName());
+			Table table = catalog.getTable("Users");
+
+			assertNotNull(table.getColumn("Id"));
+			assertNotNull(table.getColumn("FirstName"));
+		}
+	}
+
+}


### PR DESCRIPTION
This PR addresses a bug found and reported in https://github.com/quantumdb/quantumdb/issues/63#issuecomment-841695996. When initializing on a database that already contains a table, but the table's name contains uppercase characters the `determinePrimaryKeys()` method fails on a case mismatch of the name. In addition to this `addIndexes()` was also addressed, as quoted table names were fetched from the database when those table names contained uppercase characters. With this PR the `init` command should work for databases containing tables with uppercase characters in their name.

Fly-by: updating lombok to a newer version because otherwise you run into the following error when using Java 9 SDK: `java.lang.NoSuchFieldError: pid`