### PR TITLE
Identity column rename to PrimaryKey column

### DIFF
--- a/docs/docs/master/index.html
+++ b/docs/docs/master/index.html
@@ -176,7 +176,7 @@ changelog.addChangeSet("track_users", "Michael de Jong",
                 This code will create a new <code>admin</code> column in the <code>users</code> table, of type
                 <code>boolean</code>, which defaults to the <code>false</code> value, and cannot hold <code>NULL</code>
                 values. It's not required to set a default value. You can specify zero, one, or multiple hints of the
-                following types <code>AUTO_INCREMENT</code>, <code>NOT_NULL</code>, <code>IDENTITY</code>.
+                following types <code>AUTO_INCREMENT</code>, <code>NOT_NULL</code>, <code>PRIMARY_KEY</code>.
             </p>
 
             <h3>ADD FOREIGN KEY</h3>
@@ -249,7 +249,7 @@ changelog.addChangeSet("track_users", "Michael de Jong",
             <h3>CREATE TABLE</h3>
 
             <pre class="code"><code class="java">SchemaOperations.createTable("users")
-        .with("id", PostgresTypes.bigint(), Hint.IDENTITY, Hint.AUTO_INCREMENT)
+        .with("id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT)
         .with("first_name", PostgresTypes.text(), Hint.NOT_NULL)
         .with("last_name", PostgresTypes.text(), Hint.NOT_NULL));</code></pre>
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
@@ -49,7 +49,7 @@ public class XmlAddColumn implements XmlOperation<AddColumn> {
 			hints.add(Hint.AUTO_INCREMENT);
 		}
 		if (column.isPrimaryKey()) {
-			hints.add(Hint.IDENTITY);
+			hints.add(Hint.PRIMARY_KEY);
 		}
 
 		Hint[] hintArray = hints.toArray(new Hint[0]);

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
@@ -46,7 +46,7 @@ public class XmlCreateTable implements XmlOperation<CreateTable> {
 
 			List<Hint> hints = Lists.newArrayList();
 			if (column.isPrimaryKey()) {
-				hints.add(Hint.IDENTITY);
+				hints.add(Hint.PRIMARY_KEY);
 			}
 			if (column.isAutoIncrement()) {
 				hints.add(Hint.AUTO_INCREMENT);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Catalog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Catalog.java
@@ -36,7 +36,7 @@ public class Catalog implements Copyable<Catalog> {
 		checkArgument(!containsTable(table.getName()), "Catalog: '" + name + "' already contains a table: '" + table.getName() + "'.");
 		checkArgument(!containsView(table.getName()), "Catalog: '" + name + "' already contains a view: '" + table.getName() + "'.");
 		checkArgument(!table.getColumns().isEmpty(), "Table: '" + table.getName() + "' doesn't contain any columns.");
-		checkArgument(!table.getIdentityColumns().isEmpty(), "Table: '" + table.getName() + "' has no identity columns.");
+		checkArgument(!table.getPrimaryKeyColumns().isEmpty(), "Table: '" + table.getName() + "' has no primary key columns.");
 
 		tables.add(table);
 		table.setParent(this);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Column.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Column.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 public class Column implements Copyable<Column> {
 
 	public static enum Hint {
-		NOT_NULL, AUTO_INCREMENT, IDENTITY;
+		NOT_NULL, AUTO_INCREMENT, PRIMARY_KEY;
 	}
 
 	private String name;
@@ -93,8 +93,8 @@ public class Column implements Copyable<Column> {
 		this.defaultValue = null;
 	}
 
-	public boolean isIdentity() {
-		return hints.contains(Hint.IDENTITY);
+	public boolean isPrimaryKey() {
+		return hints.contains(Hint.PRIMARY_KEY);
 	}
 
 	public boolean isAutoIncrement() {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ForeignKey.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/ForeignKey.java
@@ -102,12 +102,12 @@ public class ForeignKey {
 	}
 
 	public boolean isInheritanceRelation() {
-		Set<String> identityColumns = getReferencingTable().getIdentityColumns().stream()
+		Set<String> primaryKeyColumns = getReferencingTable().getPrimaryKeyColumns().stream()
 				.map(Column::getName)
 				.collect(Collectors.toSet());
 
 		return referencingColumns.stream()
-				.anyMatch(identityColumns::contains);
+				.anyMatch(primaryKeyColumns::contains);
 	}
 
 	public void drop() {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Table.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Table.java
@@ -174,9 +174,9 @@ public class Table implements Copyable<Table>, Comparable<Table> {
 						"Table: " + name + " does not contain column: " + columnName));
 	}
 
-	public List<Column> getIdentityColumns() {
+	public List<Column> getPrimaryKeyColumns() {
 		return getColumns().stream()
-				.filter(Column::isIdentity)
+				.filter(Column::isPrimaryKey)
 				.collect(Collectors.toList());
 	}
 
@@ -195,9 +195,9 @@ public class Table implements Copyable<Table>, Comparable<Table> {
 		checkState(column.getIncomingForeignKeys().isEmpty(),
 				"You cannot remove a column that is still referenced by foreign keys.");
 
-		List<Column> identityColumns = getIdentityColumns();
-		identityColumns.remove(column);
-		checkState(!identityColumns.isEmpty(), "You drop the last remaining identity column of a table.");
+		List<Column> primaryKeyColumns = getPrimaryKeyColumns();
+		primaryKeyColumns.remove(column);
+		checkState(!primaryKeyColumns.isEmpty(), "You drop the last remaining primary key column of a table.");
 
 		if (column.getOutgoingForeignKey() != null) {
 			column.getOutgoingForeignKey().drop();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/ColumnDefinition.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/ColumnDefinition.java
@@ -42,8 +42,8 @@ public class ColumnDefinition {
 		this.hints = hints;
 	}
 
-	public boolean isIdentity() {
-		return containsHint(Column.Hint.IDENTITY);
+	public boolean isPrimaryKey() {
+		return containsHint(Column.Hint.PRIMARY_KEY);
 	}
 
 	public boolean isAutoIncrement() {

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddColumnMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bool;
 import static io.quantumdb.core.schema.definitions.TestTypes.date;
@@ -31,7 +31,7 @@ public class AddColumnMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -50,7 +50,7 @@ public class AddColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("date_of_birth", date(), "NULL"));
 
@@ -71,7 +71,7 @@ public class AddColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("date_of_birth", date(), "NULL"))
 				.addColumn(new Column("activated", bool(), "TRUE"));

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddForeignKeyMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AddForeignKeyMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,10 +29,10 @@ public class AddForeignKeyMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)))
 				.addTable(new Table("posts")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("author", integer(), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -51,7 +51,7 @@ public class AddForeignKeyMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("author", integer(), NOT_NULL));
 
 		expectedGhostTable.addForeignKey("author").referencing(usersTable, "id");

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AlterColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/AlterColumnMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.text;
@@ -31,10 +31,10 @@ public class AlterColumnMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)))
 				.addTable(new Table("referrals")
-						.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("invited_by_id", integer())));
 
 		this.changelog = new Changelog();
@@ -53,7 +53,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("full_name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -69,7 +69,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", text(), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -85,7 +85,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), "'Unknown'", NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -103,7 +103,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), "'John Smith'", NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -121,7 +121,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -137,7 +137,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("invited_by_id", integer(), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -153,7 +153,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, AUTO_INCREMENT))
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, AUTO_INCREMENT))
 				.addColumn(new Column("invited_by_id", integer()));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -169,7 +169,7 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("invited_by_id", integer(), AUTO_INCREMENT));
 
 		assertEquals(expectedGhostTable, ghostTable);
@@ -185,34 +185,34 @@ public class AlterColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL))
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL))
 				.addColumn(new Column("invited_by_id", integer()));
 
 		assertEquals(expectedGhostTable, ghostTable);
 	}
 
 	@Test
-	public void testExpandForAddingIdentityHint() {
-		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invited_by_id").addHint(IDENTITY);
-		changelog.addChangeSet("Michael de Jong", "Added IDENTITY constraint to 'invited_by_id' column.", operation);
+	public void testExpandForAddingPrimaryKeyHint() {
+		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invited_by_id").addHint(PRIMARY_KEY);
+		changelog.addChangeSet("Michael de Jong", "Added PRIMARY_KEY constraint to 'invited_by_id' column.", operation);
 		migrator.migrate(catalog, refLog, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("invitee_id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
-				.addColumn(new Column("invited_by_id", integer(), IDENTITY));
+				.addColumn(new Column("invitee_id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("invited_by_id", integer(), PRIMARY_KEY));
 
 		assertEquals(expectedGhostTable, ghostTable);
 	}
 
 	@Test
-	public void testExpandForRemovingIdentityHint() {
-		testExpandForAddingIdentityHint();
+	public void testExpandForRemovingPrimaryKeyHint() {
+		testExpandForAddingPrimaryKeyHint();
 
-		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invitee_id").dropHint(IDENTITY);
-		changelog.addChangeSet("Michael de Jong", "Dropped IDENTITY constraint of 'invitee_id' column.", operation);
+		AlterColumn operation = SchemaOperations.alterColumn("referrals", "invitee_id").dropHint(PRIMARY_KEY);
+		changelog.addChangeSet("Michael de Jong", "Dropped PRIMARY_KEY constraint of 'invitee_id' column.", operation);
 		migrator.migrate(catalog, refLog, changelog.getLastAdded(), operation);
 
 		Table originalTable = catalog.getTable("referrals");
@@ -220,7 +220,7 @@ public class AlterColumnMigratorTest {
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
 				.addColumn(new Column("invitee_id", integer(), AUTO_INCREMENT, NOT_NULL))
-				.addColumn(new Column("invited_by_id", integer(), IDENTITY));
+				.addColumn(new Column("invited_by_id", integer(), PRIMARY_KEY));
 
 		assertEquals(expectedGhostTable, ghostTable);
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CopyTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CopyTableMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -28,7 +28,7 @@ public class CopyTableMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -50,12 +50,12 @@ public class CopyTableMigratorTest {
 		String refId = refLog.getTableRef(changelog.getLastAdded(), "customers").getRefId();
 		Table ghostTable = catalog.getTable(refId);
 		Table expectedGhostTable = new Table(refId)
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table originalTable = catalog.getTable("users");
 		Table expectedOriginalTable = new Table("users")
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CreateTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/CreateTableMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -37,7 +37,7 @@ public class CreateTableMigratorTest {
 	@Test
 	public void testExpandForCopyingTable() {
 		CreateTable operation = SchemaOperations.createTable("users")
-				.with("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
+				.with("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL)
 				.with("name", varchar(255), NOT_NULL);
 
 		changelog.addChangeSet("Michael de Jong", "Creating 'users' table.", operation);
@@ -47,7 +47,7 @@ public class CreateTableMigratorTest {
 		String refId = tableRef.getRefId();
 		Table ghostTable = catalog.getTable(refId);
 		Table expectedGhostTable = new Table(refId)
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropColumnMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropColumnMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,7 +29,7 @@ public class DropColumnMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -48,13 +48,13 @@ public class DropColumnMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		assertEquals(expectedGhostTable, ghostTable);
 	}
 
 	@Test(expected = IllegalStateException.class)
-	public void testExpandForDroppingIdentityColumn() {
+	public void testExpandForDroppingPrimaryKeyColumn() {
 		DropColumn operation = SchemaOperations.dropColumn("users", "id");
 		changelog.addChangeSet("Michael de Jong", "Dropped 'id' column from 'users' table.", operation);
 		migrator.migrate(catalog, refLog, changelog.getLastAdded(), operation);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropForeignKeyMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropForeignKeyMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,10 +29,10 @@ public class DropForeignKeyMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)))
 				.addTable(new Table("posts")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("author", integer(), NOT_NULL)));
 
 		Table posts = catalog.getTable("posts");
@@ -57,7 +57,7 @@ public class DropForeignKeyMigratorTest {
 		Table ghostTable = getGhostTable(originalTable);
 
 		Table expectedGhostTable = new Table(ghostTable.getName())
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("author", integer(), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/DropTableMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,7 +29,7 @@ public class DropTableMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/RenameTableMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/RenameTableMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.integer;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -29,7 +29,7 @@ public class RenameTableMigratorTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db")
 				.addTable(new Table("users")
-						.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+						.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 						.addColumn(new Column("name", varchar(255), NOT_NULL)));
 
 		this.changelog = new Changelog();
@@ -47,7 +47,7 @@ public class RenameTableMigratorTest {
 		String refId = refLog.getTableRef(changelog.getLastAdded(), "customers").getRefId();
 		Table ghostTable = catalog.getTable(refId);
 		Table expectedGhostTable = new Table(refId)
-				.addColumn(new Column("id", integer(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		assertEquals(expectedGhostTable, ghostTable);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/SchemaOperationMigratorTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/migration/operations/SchemaOperationMigratorTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.migration.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.operations.SchemaOperations.createTable;
@@ -36,7 +36,7 @@ public class SchemaOperationMigratorTest {
 	public void testAddingNewTable() {
 		changelog.addChangeSet("test", "Michael de Jong",
 				createTable("users")
-						.with("id", bigint(), NOT_NULL, AUTO_INCREMENT, IDENTITY));
+						.with("id", bigint(), NOT_NULL, AUTO_INCREMENT, PRIMARY_KEY));
 
 		Version current = changelog.getLastAdded();
 		migrator.migrate(current, (SchemaOperation) current.getOperation());
@@ -44,7 +44,7 @@ public class SchemaOperationMigratorTest {
 		String refId = refLog.getTableRef(current, "users").getRefId();
 
 		Table expected = new Table(refId)
-				.addColumn(new Column("id", bigint(), NOT_NULL, AUTO_INCREMENT, IDENTITY));
+				.addColumn(new Column("id", bigint(), NOT_NULL, AUTO_INCREMENT, PRIMARY_KEY));
 
 		assertEquals(expected, catalog.getTable(refId));
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/CatalogTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/CatalogTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.schema.definitions;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static org.junit.Assert.assertEquals;
@@ -39,7 +39,7 @@ public class CatalogTest {
 	@Test
 	public void testAddingTableToCatalog() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -50,7 +50,7 @@ public class CatalogTest {
 	@Test
 	public void testThatContainsTableMethodReturnsTrueWhenTableExists() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -80,7 +80,7 @@ public class CatalogTest {
 	@Test
 	public void testThatGetTableMethodReturnsTableWhenItExists() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -109,7 +109,7 @@ public class CatalogTest {
 	@Test
 	public void testThatRemoveTableMethodRemovesTableWhenItExists() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -141,11 +141,11 @@ public class CatalogTest {
 	public void testRemovingTableDropsOutgoingForeignKeys() {
 		Catalog catalog = new Catalog("test-db");
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		catalog.addTable(users);
 		catalog.addTable(addresses);
@@ -163,11 +163,11 @@ public class CatalogTest {
 	public void testRemovingTableThrowsExceptionWhenIncomingForeignKeysExist() {
 		Catalog catalog = new Catalog("test-db");
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		catalog.addTable(users);
 		catalog.addTable(addresses);
@@ -181,7 +181,7 @@ public class CatalogTest {
 	@Test
 	public void testThatRenamingTableIsReflectedInCatalog() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -196,10 +196,10 @@ public class CatalogTest {
 	@Test(expected = IllegalStateException.class)
 	public void testThatRenamingTableThrowsExceptionWhenNameIsAlreadyTaken() {
 		Table usersTable = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Table playersTable = new Table("players")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		new Catalog("test-db")
 				.addTable(usersTable)
@@ -211,7 +211,7 @@ public class CatalogTest {
 	@Test
 	public void testThatCopyMethodReturnsCopy() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);
@@ -225,7 +225,7 @@ public class CatalogTest {
 	@Test
 	public void toStringReturnsSomething() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		Catalog catalog = new Catalog("test-db")
 				.addTable(table);

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/ColumnTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/ColumnTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.schema.definitions;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -24,10 +24,10 @@ public class ColumnTest {
 	}
 
 	@Test
-	public void testCreatingIdentityColumn() {
-		Column column = new Column("id", bigint(), IDENTITY);
+	public void testCreatingPrimaryKeyColumn() {
+		Column column = new Column("id", bigint(), PRIMARY_KEY);
 
-		assertTrue(column.isIdentity());
+		assertTrue(column.isPrimaryKey());
 	}
 
 	@Test
@@ -90,11 +90,11 @@ public class ColumnTest {
 	@Test
 	public void testAddingForeignKeyToSingleColumn() {
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		ForeignKey constraint = users.addForeignKey("address_id")
 				.referencing(addresses, "id");
@@ -110,22 +110,22 @@ public class ColumnTest {
 	@Test
 	public void testAddingForeignKeyToMultiColumn() {
 		Table items = new Table("items")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		Table locations = new Table("locations")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		Table stocks = new Table("stocks")
-				.addColumn(new Column("item_id", bigint(), IDENTITY, NOT_NULL))
-				.addColumn(new Column("location_id", bigint(), IDENTITY, NOT_NULL))
+				.addColumn(new Column("item_id", bigint(), PRIMARY_KEY, NOT_NULL))
+				.addColumn(new Column("location_id", bigint(), PRIMARY_KEY, NOT_NULL))
 				.addColumn(new Column("quantity", bigint(), NOT_NULL));
 
 		stocks.addForeignKey("item_id").referencing(items, "id");
 		stocks.addForeignKey("location_id").referencing(locations, "id");
 
 		Table stockNotes = new Table("stock_notes")
-				.addColumn(new Column("item_id", bigint(), IDENTITY, NOT_NULL))
-				.addColumn(new Column("location_id", bigint(), IDENTITY, NOT_NULL))
+				.addColumn(new Column("item_id", bigint(), PRIMARY_KEY, NOT_NULL))
+				.addColumn(new Column("location_id", bigint(), PRIMARY_KEY, NOT_NULL))
 				.addColumn(new Column("notes", varchar(255), NOT_NULL));
 
 		ForeignKey constraint = stockNotes.addForeignKey("item_id", "location_id")
@@ -144,11 +144,11 @@ public class ColumnTest {
 	@Test
 	public void testRemovingColumnWithOutgoingForeignKey() {
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT));
 
 		users.addForeignKey("address_id")
 				.referencing(addresses, "id");
@@ -163,11 +163,11 @@ public class ColumnTest {
 	@Test(expected = IllegalStateException.class)
 	public void testRemovingColumnWithIncomingForeignKey() {
 		Table users = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("address_id", bigint(), NOT_NULL));
 
 		Table addresses = new Table("addresses")
-				.addColumn(new Column("id", bigint(), IDENTITY, NOT_NULL, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
 				.addColumn(new Column("serial_id", bigint()));
 
 		users.addForeignKey("address_id")
@@ -210,7 +210,7 @@ public class ColumnTest {
 
 	@Test
 	public void testThatCopyMethodReturnsCopy() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL);
 		Column copy = column.copy();
 
 		assertEquals(column, copy);
@@ -219,7 +219,7 @@ public class ColumnTest {
 
 	@Test
 	public void toStringReturnsSomething() {
-		Column column = new Column("id", bigint(), "'0'", IDENTITY, NOT_NULL);
+		Column column = new Column("id", bigint(), "'0'", PRIMARY_KEY, NOT_NULL);
 
 		assertFalse(Strings.isNullOrEmpty(column.toString()));
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/TableTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/definitions/TableTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.schema.definitions;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.definitions.TestTypes.bool;
@@ -41,20 +41,20 @@ public class TableTest {
 
 	@Test
 	public void testAddingColumnToTable() {
-		new Table("users").addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+		new Table("users").addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 	}
 
 	@Test(expected = IllegalStateException.class)
 	public void testThatAddingColumnWithAnAlreadyTakenNameToTableThrowsException() {
 		new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT))
 				.addColumn(new Column("id", varchar(255)));
 	}
 
 	@Test
 	public void testAddingMutipleColumnsToTable() {
 		new Table("users").addColumns(Lists.newArrayList(
-				new Column("id", bigint(), IDENTITY, AUTO_INCREMENT),
+				new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT),
 				new Column("name", varchar(255), NOT_NULL)
 		));
 	}
@@ -67,7 +67,7 @@ public class TableTest {
 	@Test
 	public void testThatContainsColumnMethodReturnsTrueWhenColumnExists() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		assertTrue(table.containsColumn("id"));
 	}
@@ -93,7 +93,7 @@ public class TableTest {
 
 	@Test
 	public void testThatGetColumnMethodReturnsColumnWhenItExists() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 
 		assertEquals(column, table.getColumn("id"));
@@ -118,40 +118,40 @@ public class TableTest {
 	}
 
 	@Test
-	public void testThatGetIdentityColumnMethodReturnsOneColumnForTableWithoutIdentityColumns() {
+	public void testThatGetPrimaryKeyColumnMethodReturnsOneColumnForTableWithoutPrimaryKeyColumns() {
 		Table table = new Table("users")
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
-		assertTrue(table.getIdentityColumns().isEmpty());
+		assertTrue(table.getPrimaryKeyColumns().isEmpty());
 	}
 
 	@Test
-	public void testThatGetIdentityColumnMethodReturnsOneColumnForTableWithSinglePrimaryKey() {
-		Column idColumn = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+	public void testThatGetPrimaryKeyColumnMethodReturnsOneColumnForTableWithSinglePrimaryKey() {
+		Column idColumn = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 
 		Table table = new Table("users")
 				.addColumn(idColumn)
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
-		assertEquals(Lists.newArrayList(idColumn), table.getIdentityColumns());
+		assertEquals(Lists.newArrayList(idColumn), table.getPrimaryKeyColumns());
 	}
 
 	@Test
-	public void testThatGetIdentityColumnMethodReturnsOneColumnForTableWithCompositeKey() {
-		Column id1Column = new Column("left_id", bigint(), IDENTITY, AUTO_INCREMENT);
-		Column id2Column = new Column("right_id", bigint(), IDENTITY, AUTO_INCREMENT);
+	public void testThatGetPrimaryKeyColumnMethodReturnsOneColumnForTableWithCompositeKey() {
+		Column id1Column = new Column("left_id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
+		Column id2Column = new Column("right_id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 
 		Table table = new Table("link_table")
 				.addColumn(id1Column)
 				.addColumn(id2Column)
 				.addColumn(new Column("some_property", bool(), NOT_NULL));
 
-		assertEquals(Lists.newArrayList(id1Column, id2Column), table.getIdentityColumns());
+		assertEquals(Lists.newArrayList(id1Column, id2Column), table.getPrimaryKeyColumns());
 	}
 
 	@Test
 	public void testThatRemoveColumnMethodRemovesColumnWhenItExists() {
-		Column column1 = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column1 = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Column column2 = new Column("name", varchar(255), NOT_NULL);
 		Table table = new Table("users").addColumn(column1).addColumn(column2);
 
@@ -180,7 +180,7 @@ public class TableTest {
 
 	@Test
 	public void testThatRenamingColumnIsReflectedInTable() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 
 		column.rename("uuid");
@@ -198,21 +198,21 @@ public class TableTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testThatRenamingTableToNullThrowsException() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 		table.rename(null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testThatRenamingColumnToEmptyStringThrowsException() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 		table.rename("");
 	}
 
 	@Test
 	public void testThatCopyMethodReturnsCopy() {
-		Column column = new Column("id", bigint(), IDENTITY, AUTO_INCREMENT);
+		Column column = new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT);
 		Table table = new Table("users").addColumn(column);
 
 		Table copy = table.copy();
@@ -224,7 +224,7 @@ public class TableTest {
 	@Test
 	public void toStringReturnsSomething() {
 		Table table = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT));
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT));
 
 		assertFalse(Strings.isNullOrEmpty(table.toString()));
 	}

--- a/quantumdb-core/src/test/java/io/quantumdb/core/schema/operations/CreateTableTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/schema/operations/CreateTableTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.schema.operations;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
@@ -17,10 +17,10 @@ public class CreateTableTest {
 	@Test
 	public void testCreatingTableWithDefaultExpression() {
 		CreateTable operation = SchemaOperations.createTable("addresses")
-				.with("id", bigint(), "'1'", IDENTITY, NOT_NULL);
+				.with("id", bigint(), "'1'", PRIMARY_KEY, NOT_NULL);
 
 		List<ColumnDefinition> expectedColumns = Lists.newArrayList(
-				new ColumnDefinition("id", bigint(), "'1'", IDENTITY, NOT_NULL));
+				new ColumnDefinition("id", bigint(), "'1'", PRIMARY_KEY, NOT_NULL));
 
 		assertEquals("addresses", operation.getTableName());
 		assertEquals(expectedColumns, operation.getColumns());
@@ -29,7 +29,7 @@ public class CreateTableTest {
 	@Test
 	public void testCreatingTableWithMultipleColumns() {
 		CreateTable operation = SchemaOperations.createTable("addresses")
-				.with("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL)
+				.with("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL)
 				.with("street", varchar(255), NOT_NULL)
 				.with("street_number", varchar(10), NOT_NULL)
 				.with("city", varchar(255), NOT_NULL)
@@ -37,7 +37,7 @@ public class CreateTableTest {
 				.with("country", varchar(255), NOT_NULL);
 
 		List<ColumnDefinition> expectedColumns = Lists.newArrayList(
-				new ColumnDefinition("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL),
+				new ColumnDefinition("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL),
 				new ColumnDefinition("street", varchar(255), NOT_NULL),
 				new ColumnDefinition("street_number", varchar(10), NOT_NULL),
 				new ColumnDefinition("city", varchar(255), NOT_NULL),
@@ -62,19 +62,19 @@ public class CreateTableTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreatingTableWithNullForColumnName() {
 		SchemaOperations.createTable("addresses")
-				.with(null, bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL);
+				.with(null, bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreatingTableWithEmptyStringForColumnName() {
 		SchemaOperations.createTable("addresses")
-				.with("", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL);
+				.with("", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreatingTableWithNullForColumnType() {
 		SchemaOperations.createTable("addresses")
-				.with("id", null, IDENTITY, AUTO_INCREMENT, NOT_NULL);
+				.with("id", null, PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL);
 	}
 
 }

--- a/quantumdb-core/src/test/java/io/quantumdb/core/state/RefLogTest.java
+++ b/quantumdb-core/src/test/java/io/quantumdb/core/state/RefLogTest.java
@@ -1,6 +1,6 @@
 package io.quantumdb.core.state;
 
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.TestTypes.bigint;
 import static io.quantumdb.core.schema.definitions.TestTypes.varchar;
 import static io.quantumdb.core.utils.RandomHasher.generateHash;
@@ -38,7 +38,7 @@ public class RefLogTest {
 	public void setUp() {
 		this.catalog = new Catalog("test-db");
 		catalog.addTable(new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY))
 				.addColumn(new Column("name", varchar(255))));
 
 		this.version = new Version(generateHash(), null);

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
@@ -110,7 +110,7 @@ class CatalogLoader {
 					hints.add(Column.Hint.NOT_NULL);
 				}
 				if (primaryKeys.contains(columnName) || (primaryKeys.isEmpty() && columns.isEmpty())) {
-					hints.add(Column.Hint.IDENTITY);
+					hints.add(Column.Hint.PRIMARY_KEY);
 				}
 
 				Sequence sequence = null;

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlMigrationPlanner.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlMigrationPlanner.java
@@ -201,15 +201,15 @@ public class PostgresqlMigrationPlanner implements MigrationPlanner {
 						.map(Column::getName)
 						.collect(Collectors.toCollection(Sets::newLinkedHashSet));
 
-				Set<String> identityColumns = table.getIdentityColumns().stream()
+				Set<String> primaryKeyColumns = table.getPrimaryKeyColumns().stream()
 						.map(Column::getName)
 						.collect(Collectors.toSet());
 
-				SetView<String> missingIdentityColumns = Sets.difference(identityColumns, columns);
-				if (!missingIdentityColumns.isEmpty()) {
+				SetView<String> missingPrimaryKeyColumns = Sets.difference(primaryKeyColumns, columns);
+				if (!missingPrimaryKeyColumns.isEmpty()) {
 					toMigrate.add(0, refId);
 
-					List<Table> parentTables = table.getIdentityColumns().stream()
+					List<Table> parentTables = table.getPrimaryKeyColumns().stream()
 							.map(Column::getOutgoingForeignKey)
 							.map(ForeignKey::getReferredTable)
 							.distinct()
@@ -287,15 +287,15 @@ public class PostgresqlMigrationPlanner implements MigrationPlanner {
 						.map(Column::getName)
 						.collect(Collectors.toCollection(Sets::newLinkedHashSet));
 
-				Set<String> identityColumns = table.getIdentityColumns().stream()
+				Set<String> primaryKeyColumns = table.getPrimaryKeyColumns().stream()
 						.map(Column::getName)
 						.collect(Collectors.toSet());
 
-				SetView<String> missingIdentityColumns = Sets.difference(identityColumns, columns);
-				if (!missingIdentityColumns.isEmpty()) {
+				SetView<String> missingPrimaryKeyColumns = Sets.difference(primaryKeyColumns, columns);
+				if (!missingPrimaryKeyColumns.isEmpty()) {
 					toMigrate.add(0, refId);
 
-					List<Table> parentTables = table.getIdentityColumns().stream()
+					List<Table> parentTables = table.getPrimaryKeyColumns().stream()
 							.map(Column::getOutgoingForeignKey)
 							.map(ForeignKey::getReferredTable)
 							.distinct()

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SyncFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SyncFunction.java
@@ -75,7 +75,7 @@ public class SyncFunction {
 		Map<String, String> mapping = columnMapping.entrySet().stream()
 				.filter(entry -> {
 					Column column = sourceTable.getColumn(entry.getKey().getName());
-					return columnsToMigrate.contains(entry.getValue().getName()) || column.isIdentity();
+					return columnsToMigrate.contains(entry.getValue().getName()) || column.isPrimaryKey();
 				})
 				.collect(Collectors.toMap(entry -> entry.getKey().getName(), entry -> entry.getValue().getName()));
 
@@ -112,13 +112,13 @@ public class SyncFunction {
 		this.insertExpressions = ImmutableMap.copyOf(expressions);
 		this.updateExpressions = ImmutableMap.copyOf(insertExpressions);
 
-		this.updateIdentitiesForInserts = ImmutableMap.copyOf((Map<? extends String, ? extends String>)targetTable.getIdentityColumns().stream()
+		this.updateIdentitiesForInserts = ImmutableMap.copyOf((Map<? extends String, ? extends String>)targetTable.getPrimaryKeyColumns().stream()
 				.collect(Collectors.toMap(column -> "\"" + column.getName() + "\"",
 						column -> "NEW.\"" + reverseLookup(mapping, column.getName()) + "\"",
 						(u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },
 						Maps::newLinkedHashMap)));
 
-		this.updateIdentities = ImmutableMap.copyOf((Map<? extends String, ? extends String>)targetTable.getIdentityColumns().stream()
+		this.updateIdentities = ImmutableMap.copyOf((Map<? extends String, ? extends String>)targetTable.getPrimaryKeyColumns().stream()
 				.collect(Collectors.toMap(column -> "\"" + column.getName() + "\"",
 						column -> "OLD.\"" + reverseLookup(mapping, column.getName()) + "\"",
 						(u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
@@ -87,12 +87,12 @@ public class TableCreator {
 			columnAdded = true;
 		}
 
-		List<String> identityColumns = table.getIdentityColumns().stream()
+		List<String> primaryKeyColumns = table.getPrimaryKeyColumns().stream()
 				.map(Column::getName)
 				.collect(Collectors.toList());
 
-		if (!identityColumns.isEmpty()) {
-			queryBuilder.append(", PRIMARY KEY(" + Joiner.on(", ").join(identityColumns) + ")");
+		if (!primaryKeyColumns.isEmpty()) {
+			queryBuilder.append(", PRIMARY KEY(" + Joiner.on(", ").join(primaryKeyColumns) + ")");
 		}
 
 		queryBuilder.append(")");

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -121,25 +121,25 @@ class TableDataMigrator {
 	}
 
 	private Map<String, Object> queryHighestId(Table from) throws SQLException {
-		List<String> identityColumns = from.getIdentityColumns().stream()
+		List<String> primaryKeyColumns = from.getPrimaryKeyColumns().stream()
 				.map(Column::getName)
 				.collect(Collectors.toList());
 
 		try (Connection connection = backend.connect()) {
 			try (Statement statement = connection.createStatement()) {
 				String query = new QueryBuilder()
-						.append("SELECT " + Joiner.on(", ").join(identityColumns))
+						.append("SELECT " + Joiner.on(", ").join(primaryKeyColumns))
 						.append("FROM " + from.getName())
-						.append("ORDER BY " + Joiner.on(" DESC, ").join(identityColumns) + " DESC")
+						.append("ORDER BY " + Joiner.on(" DESC, ").join(primaryKeyColumns) + " DESC")
 						.append("LIMIT 1")
 						.toString();
 
 				ResultSet resultSet = statement.executeQuery(query);
 				if (resultSet.next()) {
 					Map<String, Object> id = Maps.newHashMap();
-					for (String identityColumn : identityColumns) {
-						Object value = resultSet.getObject(identityColumn);
-						id.put(identityColumn, value);
+					for (String primaryKeyColumn : primaryKeyColumns) {
+						Object value = resultSet.getObject(primaryKeyColumn);
+						id.put(primaryKeyColumn, value);
 					}
 					return id;
 				}
@@ -154,7 +154,7 @@ class TableDataMigrator {
 			Object right = limit.get(key);
 
 			if (left == null || right == null) {
-				throw new IllegalStateException("NULL values in identity columns are currently not supported.");
+				throw new IllegalStateException("NULL values in primary key columns are currently not supported.");
 			}
 
 			if (!(left instanceof Comparable)) {
@@ -221,9 +221,9 @@ class TableDataMigrator {
 		}
 
 		Map<String, Object> identity = Maps.newHashMap();
-		List<Column> identityColumns = from.getIdentityColumns();
-		for (int i = 0; i < identityColumns.size(); i++) {
-			Column column = identityColumns.get(i);
+		List<Column> primaryKeyColumns = from.getPrimaryKeyColumns();
+		for (int i = 0; i < primaryKeyColumns.size(); i++) {
+			Column column = primaryKeyColumns.get(i);
 			String columnName = column.getName();
 			Object value = parseValue(column.getType().getType(), parts.get(i));
 			identity.put(columnName, value);

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/TransactionalityTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/TransactionalityTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.integer;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.varchar;
@@ -50,11 +50,11 @@ public class TransactionalityTest {
 		Catalog catalog = new Catalog(database.getCatalogName());
 
 		Table source = new Table("source")
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table target = new Table("target")
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		catalog.addTable(source);

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.integration.multistate;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
@@ -50,7 +50,7 @@ public class MultiStateTest extends PostgresqlDatabase {
 		step0 = changelog.getRoot();
 
 		step1 = changelog.addChangeSet("step1", "Michael de Jong", "Create test table.",
-				createTable("test").with("id", bigint(), IDENTITY, AUTO_INCREMENT))
+				createTable("test").with("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT))
 				.getLastAdded();
 
 		changelog.addChangeSet("step2", "Michael de Jong", "Add name column to test table.",

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -67,38 +67,38 @@ public class AddColumnToCustomersTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -106,7 +106,7 @@ public class AddColumnToCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -129,35 +129,35 @@ public class AddColumnToCustomersTable {
 		// New tables and foreign keys.
 
 		Table newStores = new Table(refLog.getTableRef(target, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table newStaff = new Table(refLog.getTableRef(target, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table newInventory = new Table(refLog.getTableRef(target, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table newPaychecks = new Table(refLog.getTableRef(target, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers").getRefId())
-				.addColumn(new Column("id", integer(), customers.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), customers.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()))
 				.addColumn(new Column("date_of_birth", date()));
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -165,7 +165,7 @@ public class AddColumnToCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), rentals.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), rentals.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -65,38 +65,38 @@ public class AddColumnToFilmsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -104,7 +104,7 @@ public class AddColumnToFilmsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -127,17 +127,17 @@ public class AddColumnToFilmsTable {
 		// New tables and foreign keys.
 
 		Table newFilms = new Table(refLog.getTableRef(target, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("release_date", date()));
 
 		Table newInventory = new Table(refLog.getTableRef(target, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -145,7 +145,7 @@ public class AddColumnToFilmsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
@@ -66,38 +66,38 @@ public class AddColumnToPaymentsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -105,7 +105,7 @@ public class AddColumnToPaymentsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -128,7 +128,7 @@ public class AddColumnToPaymentsTable {
 		// New tables and foreign keys.
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -68,38 +68,38 @@ public class AddForeignKeyToPaymentsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -107,7 +107,7 @@ public class AddForeignKeyToPaymentsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -130,7 +130,7 @@ public class AddForeignKeyToPaymentsTable {
 		// New tables and foreign keys.
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -67,38 +67,38 @@ public class CopyCustomersTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -106,7 +106,7 @@ public class CopyCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -129,7 +129,7 @@ public class CopyCustomersTable {
 		// New tables and foreign keys.
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers_backup").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -51,7 +51,7 @@ public class CreateCreditCardsTable {
 
 		setup.getChangelog().addChangeSet("test", "Michael de Jong",
 				SchemaOperations.createTable("credit_cards")
-						.with("credit_card_number", varchar(255), IDENTITY, NOT_NULL)
+						.with("credit_card_number", varchar(255), PRIMARY_KEY, NOT_NULL)
 						.with("card_holder_name", varchar(255), NOT_NULL)
 						.with("expiration_date", date(), NOT_NULL));
 
@@ -70,38 +70,38 @@ public class CreateCreditCardsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -109,7 +109,7 @@ public class CreateCreditCardsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -132,7 +132,7 @@ public class CreateCreditCardsTable {
 		// New tables and foreign keys.
 
 		Table creditCards = new Table(refLog.getTableRef(target, "credit_cards").getRefId())
-				.addColumn(new Column("credit_card_number", varchar(255), IDENTITY, NOT_NULL))
+				.addColumn(new Column("credit_card_number", varchar(255), PRIMARY_KEY, NOT_NULL))
 				.addColumn(new Column("card_holder_name", varchar(255), NOT_NULL))
 				.addColumn(new Column("expiration_date", date(), NOT_NULL));
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -65,38 +65,38 @@ public class DropColumnFromCustomersTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -104,7 +104,7 @@ public class DropColumnFromCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -127,12 +127,12 @@ public class DropColumnFromCustomersTable {
 		// New tables and foreign keys.
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -140,7 +140,7 @@ public class DropColumnFromCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -67,38 +67,38 @@ public class DropForeignKeyFromCustomersTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -106,7 +106,7 @@ public class DropForeignKeyFromCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -129,7 +129,7 @@ public class DropForeignKeyFromCustomersTable {
 		// New tables and foreign keys.
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -137,14 +137,14 @@ public class DropForeignKeyFromCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL));
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
@@ -8,7 +8,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -64,38 +64,38 @@ public class DropPaymentsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -103,7 +103,7 @@ public class DropPaymentsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.integration.videostores;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -63,38 +63,38 @@ public class MakeStoreFieldInStaffTableNullable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -102,7 +102,7 @@ public class MakeStoreFieldInStaffTableNullable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -125,34 +125,34 @@ public class MakeStoreFieldInStaffTableNullable {
 		// New tables and foreign keys.
 
 		Table newStores = new Table(refLog.getTableRef(target, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table newStaff = new Table(refLog.getTableRef(target, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer()));
 
 		Table newCustomers = new Table(refLog.getTableRef(target, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table newInventory = new Table(refLog.getTableRef(target, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table newPaychecks = new Table(refLog.getTableRef(target, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -160,7 +160,7 @@ public class MakeStoreFieldInStaffTableNullable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table newRentals = new Table(refLog.getTableRef(target, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.doubles;
@@ -67,38 +67,38 @@ public class ModifyTypeInPaymentsTable {
 		// Original tables and foreign keys.
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -106,7 +106,7 @@ public class ModifyTypeInPaymentsTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))
@@ -129,7 +129,7 @@ public class ModifyTypeInPaymentsTable {
 		// New tables and foreign keys.
 
 		Table newPayments = new Table(refLog.getTableRef(target, "payments").getRefId())
-				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), payments.getColumn("id").getSequence(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/PostgresqlBaseScenario.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/PostgresqlBaseScenario.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.integration.videostores;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -59,38 +59,38 @@ public class PostgresqlBaseScenario extends PostgresqlDatabase {
 		TableCreator tableCreator = new TableCreator();
 
 		Table stores = new Table(STORES_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(STAFF_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(CUSTOMERS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(FILMS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(INVENTORY_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(PAYCHECKS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(PAYMENTS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -98,7 +98,7 @@ public class PostgresqlBaseScenario extends PostgresqlDatabase {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(RENTALS_ID)
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
@@ -9,7 +9,7 @@ import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseS
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STAFF_ID;
 import static io.quantumdb.core.backends.integration.videostores.PostgresqlBaseScenario.STORES_ID;
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.date;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.floats;
@@ -66,38 +66,38 @@ public class RenameCustomersTable {
 		RefLog refLog = state.getRefLog();
 
 		Table stores = new Table(refLog.getTableRef(origin, "stores").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 		Table staff = new Table(refLog.getTableRef(origin, "staff").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 		Table customers = new Table(refLog.getTableRef(origin, "customers").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("referred_by", integer()));
 
 		Table films = new Table(refLog.getTableRef(origin, "films").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table inventory = new Table(refLog.getTableRef(origin, "inventory").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("store_id", integer(), NOT_NULL))
 				.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 		Table paychecks = new Table(refLog.getTableRef(origin, "paychecks").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer(), NOT_NULL))
 				.addColumn(new Column("date", date(), NOT_NULL))
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table payments = new Table(refLog.getTableRef(origin, "payments").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("rental_id", integer(), NOT_NULL))
@@ -105,7 +105,7 @@ public class RenameCustomersTable {
 				.addColumn(new Column("amount", floats(), NOT_NULL));
 
 		Table rentals = new Table(refLog.getTableRef(origin, "rentals").getRefId())
-				.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("staff_id", integer()))
 				.addColumn(new Column("customer_id", integer(), NOT_NULL))
 				.addColumn(new Column("inventory_id", integer(), NOT_NULL))

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/GreedyMigrationPlannerTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/GreedyMigrationPlannerTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.planner;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
@@ -86,7 +86,7 @@ public class GreedyMigrationPlannerTest {
 			Catalog catalog = new Catalog("fullMagnet");
 
 			Table answeredQuestions = new Table("answered_questions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("jobseeker_id", bigint()))
 					.addColumn(new Column("is_positive", bool(), NOT_NULL))
@@ -95,10 +95,10 @@ public class GreedyMigrationPlannerTest {
 
 			Table applicationAttachments = new Table("application_attachments")
 					.addColumn(new Column("application_id", bigint(), NOT_NULL))
-					.addColumn(new Column("attachment_id", bigint(), NOT_NULL, IDENTITY));
+					.addColumn(new Column("attachment_id", bigint(), NOT_NULL, PRIMARY_KEY));
 
 			Table applications = new Table("applications")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL))
 					.addColumn(new Column("opportunity_id", bigint(), NOT_NULL))
@@ -108,14 +108,14 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table applicationsResponses = new Table("applications__responses")
-					.addColumn(new Column("application_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("application_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("message", text()))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table cloudImages = new Table("cloud_images")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("bucket", varchar(255), NOT_NULL))
 					.addColumn(new Column("folder", varchar(255)))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
@@ -124,12 +124,12 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table companies = new Table("companies")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("employees", integer()));
 
 			Table conversationSubscribers = new Table("conversation_subscribers")
-					.addColumn(new Column("conversation_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("subscriber_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("conversation_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("subscriber_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("starred", bool(), "'false'", NOT_NULL))
 					.addColumn(new Column("archived", bool(), "'false'", NOT_NULL))
 					.addColumn(new Column("last_read_message_id", bigint()))
@@ -137,7 +137,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table conversations = new Table("conversations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("title", varchar(255), NOT_NULL))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("sender_id", bigint(), NOT_NULL))
@@ -146,7 +146,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table databasechangelog = new Table("databasechangelog")
-					.addColumn(new Column("id", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("author", varchar(255), NOT_NULL))
 					.addColumn(new Column("filename", varchar(255), NOT_NULL))
 					.addColumn(new Column("dateexecuted", timestamp(true), NOT_NULL))
@@ -159,26 +159,26 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("liquibase", varchar(255)));
 
 			Table databasechangeloglock = new Table("databasechangeloglock")
-					.addColumn(new Column("id", integer(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", integer(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("locked", bool(), NOT_NULL))
 					.addColumn(new Column("lockgranted", timestamp(true)))
 					.addColumn(new Column("lockedby", varchar(255)));
 
 			Table deletedUsers = new Table("deleted_users")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("email", varchar(255), NOT_NULL))
 					.addColumn(new Column("deleted_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("found_job_via_magnet", bool()))
 					.addColumn(new Column("invalid_email", bool(), "'false'", NOT_NULL));
 
 			Table educationNames = new Table("education_names")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table educations = new Table("educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("institution_id", bigint(), NOT_NULL))
 					.addColumn(new Column("education_name_id", bigint(), NOT_NULL))
 					.addColumn(new Column("level", varchar(255), NOT_NULL))
@@ -188,12 +188,12 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table emailOptOut = new Table("email_opt_out")
-					.addColumn(new Column("email", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("email", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table employeesPerCountry = new Table("employees_per_country")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("country", varchar(255), NOT_NULL))
 					.addColumn(new Column("number_of_employees", integer(), NOT_NULL))
 					.addColumn(new Column("company_id", bigint(), NOT_NULL))
@@ -201,26 +201,26 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table eventOrganizers = new Table("event_organizers")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT));
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT));
 
 			Table experiences = new Table("experiences")
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("hours_per_week_spent", integer()))
 					.addColumn(new Column("weeks_spent", integer(), NOT_NULL))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("institute_name", varchar(255)))
 					.addColumn(new Column("country", varchar(255)))
 					.addColumn(new Column("city", varchar(255)));
 
 			Table extraCurricularExperiences = new Table("extra_curricular_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("volunteer", bool(), "'false'", NOT_NULL))
 					.addColumn(new Column("work_type", varchar(255)))
 					.addColumn(new Column("second_work_type", varchar(255)));
 
 			Table featureFlags = new Table("feature_flags")
-					.addColumn(new Column("user_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("feature", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("user_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("feature", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
@@ -231,12 +231,12 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("created_by_user_id", bigint(), NOT_NULL))
 					.addColumn(new Column("created", timestamp(true), NOT_NULL))
 					.addColumn(new Column("name", varchar(255)))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table institutions = new Table("institutions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("url", varchar(255)))
 					.addColumn(new Column("verified", bool(), "'false'", NOT_NULL))
@@ -247,7 +247,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table invites = new Table("invites")
-					.addColumn(new Column("id", uuid(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", uuid(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("email", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("invited_by", bigint()))
@@ -257,7 +257,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table jobSeekerEmailPreferences = new Table("job_seeker_email_preferences")
-					.addColumn(new Column("user_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("user_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("personal_messages", bool(), "'true'", NOT_NULL))
 					.addColumn(new Column("application_response", bool(), "'true'", NOT_NULL))
 					.addColumn(new Column("network_requests", varchar(255), "''IMMEDIATELY'::character varying'", NOT_NULL))
@@ -271,7 +271,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("last_profile_view_sent_at", timestamp(true)));
 
 			Table jobseekersSavedOpportunities = new Table("jobseekers__saved_opportunities")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("jobseeker_id", bigint()))
 					.addColumn(new Column("opportunity_id", bigint()))
 					.addColumn(new Column("saved_at", timestamp(true), "'now()'", NOT_NULL))
@@ -280,7 +280,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("opportunity_name", varchar(255)));
 
 			Table languageSkills = new Table("language_skills")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("level", varchar(255), NOT_NULL))
 					.addColumn(new Column("language", varchar(255), NOT_NULL))
@@ -288,7 +288,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table magnetTransactions = new Table("magnet_transactions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("date", timestamp(true), NOT_NULL))
 					.addColumn(new Column("delta", integer(), NOT_NULL))
@@ -304,7 +304,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("invited_user_id", bigint()));
 
 			Table messages = new Table("messages")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("body", text(), NOT_NULL))
 					.addColumn(new Column("sender_id", bigint(), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
@@ -312,11 +312,11 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table networkOpportunities = new Table("network_opportunities")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("opportunity_id", bigint(), NOT_NULL, IDENTITY));
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("opportunity_id", bigint(), NOT_NULL, PRIMARY_KEY));
 
 			Table networks = new Table("networks")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("active", bool(), "'true'", NOT_NULL))
@@ -342,12 +342,12 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("master_edu_weight", varchar(255)));
 
 			Table networksRecruiters = new Table("networks__recruiters")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("update_subscription", varchar(255), "''IMMEDIATELY'::character varying'", NOT_NULL));
 
 			Table newsPosts = new Table("news_posts")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("type", varchar(255), NOT_NULL))
 					.addColumn(new Column("body", text(), NOT_NULL))
 					.addColumn(new Column("poster_id", bigint(), NOT_NULL))
@@ -359,11 +359,11 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table newsPostsNetworks = new Table("news_posts__networks")
-					.addColumn(new Column("news_post_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY));
+					.addColumn(new Column("news_post_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY));
 
 			Table occupations = new Table("occupations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("started", date(), NOT_NULL))
 					.addColumn(new Column("finished", date()))
@@ -374,7 +374,7 @@ public class GreedyMigrationPlannerTest {
 
 			Table opportunities = new Table("opportunities")
 					.addColumn(new Column("type", varchar(255), NOT_NULL))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
@@ -402,8 +402,8 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("end_time", timestamp(true)));
 
 			Table organizationPages = new Table("organization_pages")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("organization_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("organization_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("heading", varchar(255), NOT_NULL))
 					.addColumn(new Column("text", text()))
 					.addColumn(new Column("image_id", bigint()))
@@ -416,7 +416,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table organizationTags = new Table("organization_tags")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("organization_id", bigint()))
 					.addColumn(new Column("color", chars(255)))
@@ -425,7 +425,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("last_used", timestamp(true), "'now()'", NOT_NULL));
 
 			Table organizations = new Table("organizations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("active", bool(), "'false'", NOT_NULL))
 					.addColumn(new Column("name", varchar(255)))
 					.addColumn(new Column("phone_number", varchar(255)))
@@ -454,11 +454,11 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("questionnaire_priority", integer()));
 
 			Table pepCountries = new Table("pep_countries")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("country", varchar(255), NOT_NULL));
 
 			Table pepExperienceIndustries = new Table("pep_experience_industries")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("experience_id", bigint(), NOT_NULL))
 					.addColumn(new Column("industry", varchar(255), NOT_NULL))
 					.addColumn(new Column("weight", varchar(255)))
@@ -466,21 +466,21 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepExperienceWorkTypes = new Table("pep_experience_work_types")
-					.addColumn(new Column("experience_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("work_type", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("experience_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("work_type", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("weight", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterAbroad = new Table("pep_filter_abroad")
-					.addColumn(new Column("experience_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("type", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("experience_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("type", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("weight", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducations = new Table("pep_filter_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
 					.addColumn(new Column("reject_policy", varchar(255), NOT_NULL))
 					.addColumn(new Column("type", varchar(255), NOT_NULL))
@@ -500,21 +500,21 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsHasSelectedDisciplines = new Table("pep_filter_educations__has_selected_disciplines")
-					.addColumn(new Column("pep_filter_education_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("pep_filter_education_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("selected_discipline", varchar(255)))
 					.addColumn(new Column("weight", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsHasSelectedSubdisciplines = new Table("pep_filter_educations__has_selected_subdisciplines")
-					.addColumn(new Column("pep_filter_education_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("pep_filter_education_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("selected_subdiscipline", varchar(255), NOT_NULL))
 					.addColumn(new Column("weight", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsSelectedEducationNames = new Table("pep_filter_educations__selected_education_names")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("pep_filter_education_id", bigint()))
 					.addColumn(new Column("included", bool(), NOT_NULL))
 					.addColumn(new Column("education_name_id", bigint()))
@@ -522,7 +522,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsSelectedEducations = new Table("pep_filter_educations__selected_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("pep_filter_education_id", bigint()))
 					.addColumn(new Column("included", bool(), NOT_NULL))
 					.addColumn(new Column("education_id", bigint()))
@@ -530,7 +530,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterEducationsSelectedInstitutions = new Table("pep_filter_educations__selected_institutions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("pep_filter_education_id", bigint()))
 					.addColumn(new Column("included", bool(), NOT_NULL))
 					.addColumn(new Column("institution_id", bigint()))
@@ -538,7 +538,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterExperiences = new Table("pep_filter_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
 					.addColumn(new Column("reject_policy", varchar(255), NOT_NULL))
 					.addColumn(new Column("network_id", bigint()))
@@ -549,7 +549,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterLanguages = new Table("pep_filter_languages")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
 					.addColumn(new Column("reject_policy", varchar(255), NOT_NULL))
 					.addColumn(new Column("network_id", bigint()))
@@ -559,7 +559,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterTools = new Table("pep_filter_tools")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
 					.addColumn(new Column("reject_policy", varchar(255), NOT_NULL))
 					.addColumn(new Column("network_id", bigint()))
@@ -569,7 +569,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepFilterTravels = new Table("pep_filter_travels")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("network_id", bigint()))
 					.addColumn(new Column("minimum_months", integer(), NOT_NULL))
 					.addColumn(new Column("weight", varchar(255), NOT_NULL))
@@ -578,19 +578,19 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepJobLevels = new Table("pep_job_levels")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("job_level", varchar(255), NOT_NULL, IDENTITY));
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("job_level", varchar(255), NOT_NULL, PRIMARY_KEY));
 
 			Table pepJobtypes = new Table("pep_jobtypes")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("jobtype", varchar(255), NOT_NULL, IDENTITY));
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("jobtype", varchar(255), NOT_NULL, PRIMARY_KEY));
 
 			Table pepStudyPhases = new Table("pep_study_phases")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("study_phase", varchar(255), NOT_NULL, IDENTITY));
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("study_phase", varchar(255), NOT_NULL, PRIMARY_KEY));
 
 			Table pepUpdateRequests = new Table("pep_update_requests")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("type", varchar(255), NOT_NULL))
 					.addColumn(new Column("work_started_at", timestamp(true)))
 					.addColumn(new Column("work_started_by", varchar(255)))
@@ -605,20 +605,20 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table pepWorkTypes = new Table("pep_work_types")
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("work_type", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table premiumRenewals = new Table("premium_renewals")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("start_date", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("invite_id", uuid()))
 					.addColumn(new Column("days", integer(), NOT_NULL));
 
 			Table profileViews = new Table("profile_views")
-					.addColumn(new Column("id", bigint(), "'nextval('profile_views_id_seq1'::regclass)'", NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), "'nextval('profile_views_id_seq1'::regclass)'", NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("recruiter_id", bigint()))
 					.addColumn(new Column("date", date(), "'now()'", NOT_NULL))
@@ -627,7 +627,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("mailed", bool(), "'false'", NOT_NULL));
 
 			Table purchases = new Table("purchases")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("key", varchar(255), NOT_NULL))
 					.addColumn(new Column("permission_value", integer()))
@@ -635,11 +635,11 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table queuedMailTags = new Table("queued_mail_tags")
-					.addColumn(new Column("mail_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("mail_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("tag", varchar(255)));
 
 			Table queuedMails = new Table("queued_mails")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("delivery_time", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("to_name", varchar(255)))
@@ -656,7 +656,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("track_id", varchar(255)));
 
 			Table recruiterEmailPreferences = new Table("recruiter_email_preferences")
-					.addColumn(new Column("user_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("user_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("personal_messages", bool(), "'true'", NOT_NULL))
 					.addColumn(new Column("application", varchar(255), "''IMMEDIATELY'::character varying'", NOT_NULL))
 					.addColumn(new Column("bounce_problems", timestamp(true)))
@@ -665,80 +665,80 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table recruiters = new Table("recruiters")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("role", text()))
 					.addColumn(new Column("visibility", varchar(255), "''NETWORK'::character varying'", NOT_NULL))
 					.addColumn(new Column("timeline_feed_intro_seen", bool(), "'false'"));
 
 			Table scheduledNetworkRequestEmails = new Table("scheduled_network_request_emails")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("scheduled", timestamp(true), NOT_NULL))
 					.addColumn(new Column("deliver_at", timestamp(true), NOT_NULL))
 					.addColumn(new Column("sent_at", timestamp(true)))
 					.addColumn(new Column("requests_sent", integer()));
 
 			Table scheduledNewInNetworkEmails = new Table("scheduled_new_in_network_emails")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("recruiter_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("scheduled", timestamp(true), NOT_NULL))
 					.addColumn(new Column("deliver_at", timestamp(true), NOT_NULL))
 					.addColumn(new Column("sent_at", timestamp(true)))
 					.addColumn(new Column("job_seekers_sent", integer()));
 
 			Table scheduledOnboardingEmails = new Table("scheduled_onboarding_emails")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
-					.addColumn(new Column("jobseeker_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
+					.addColumn(new Column("jobseeker_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("scheduled", timestamp(true), NOT_NULL))
 					.addColumn(new Column("deliver_at", timestamp(true), NOT_NULL))
 					.addColumn(new Column("sent_at", timestamp(true)));
 
 			Table scheduledQuestions = new Table("scheduled_questions")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("jobseeker_id", bigint(), NOT_NULL))
 					.addColumn(new Column("organization_id", bigint(), NOT_NULL))
 					.addColumn(new Column("saved_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("is_positive", bool(), NOT_NULL));
 
 			Table sportExperiences = new Table("sport_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY));
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY));
 
 			Table studentCompanySizeInterests = new Table("student_company_size_interests")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("company_size", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentHighSchools = new Table("student_high_schools")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("level", varchar(255)))
 					.addColumn(new Column("school_name", varchar(255)))
 					.addColumn(new Column("city", varchar(255), NOT_NULL))
 					.addColumn(new Column("country", varchar(255), NOT_NULL));
 
 			Table studentHigherEducations = new Table("student_higher_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("aborted", bool(), "'false'"))
 					.addColumn(new Column("education_id", bigint()))
 					.addColumn(new Column("nominal_duration", integer(), NOT_NULL));
 
 			Table studentInterestedIndustries = new Table("student_interested_industries")
-					.addColumn(new Column("student_id", bigint(), IDENTITY))
+					.addColumn(new Column("student_id", bigint(), PRIMARY_KEY))
 					.addColumn(new Column("industries", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentInterestedWorkTypes = new Table("student_interested_work_types")
-					.addColumn(new Column("student_id", bigint(), IDENTITY))
+					.addColumn(new Column("student_id", bigint(), PRIMARY_KEY))
 					.addColumn(new Column("types_of_work", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentOtherEducations = new Table("student_other_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("institute", varchar(255)))
 					.addColumn(new Column("migrate_suggestion", varchar(255)))
@@ -748,7 +748,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table students = new Table("students")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("date_of_birth", date()))
 					.addColumn(new Column("invited_by", bigint()))
 					.addColumn(new Column("status", varchar(255)))
@@ -773,12 +773,12 @@ public class GreedyMigrationPlannerTest {
 
 			Table studentsEducations = new Table("students__educations")
 					.addColumn(new Column("gpa", floats()))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("graduated", bool()));
 
 			Table studentsNetworks = new Table("students__networks")
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
-					.addColumn(new Column("network_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("network_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("status", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'", NOT_NULL))
 					.addColumn(new Column("updated_at", timestamp(true), "'now()'", NOT_NULL))
@@ -788,30 +788,30 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("responded_at", timestamp(true)));
 
 			Table studentsOrganizationsTags = new Table("students__organizations__tags")
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("tag_id", bigint()));
 
 			Table studentsPhotos = new Table("students__photos")
-					.addColumn(new Column("student_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("student_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("cloud_image_id", bigint(), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentsUploads = new Table("students__uploads")
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
-					.addColumn(new Column("attachment_id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("attachment_id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table subscriptionsPermissions = new Table("subscriptions__permissions")
-					.addColumn(new Column("subscription", varchar(255), NOT_NULL, IDENTITY))
-					.addColumn(new Column("key", varchar(255), NOT_NULL, IDENTITY))
+					.addColumn(new Column("subscription", varchar(255), NOT_NULL, PRIMARY_KEY))
+					.addColumn(new Column("key", varchar(255), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("permission_value", integer()))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table toolSkills = new Table("tool_skills")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("level", varchar(255), NOT_NULL))
 					.addColumn(new Column("tool_id", bigint()))
@@ -819,13 +819,13 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table tools = new Table("tools")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table travelExperiences = new Table("travel_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("summary", varchar(255), NOT_NULL))
 					.addColumn(new Column("location", varchar(255), NOT_NULL))
@@ -836,7 +836,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table users = new Table("users")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("email", varchar(255), NOT_NULL))
 					.addColumn(new Column("first_name", varchar(255), NOT_NULL))
 					.addColumn(new Column("last_name", varchar(255), NOT_NULL))
@@ -870,7 +870,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table workExperiences = new Table("work_experiences")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("role", varchar(255)))
 					.addColumn(new Column("industry", varchar(255), "''OTHER'::character varying'"))
 					.addColumn(new Column("internship", bool(), "'false'", NOT_NULL))
@@ -879,7 +879,7 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("second_work_type", varchar(255)));
 
 			Table youtubeVideos = new Table("youtube_videos")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY, AUTO_INCREMENT))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY, AUTO_INCREMENT))
 					.addColumn(new Column("video_id", varchar(255)))
 					.addColumn(new Column("title", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
@@ -1113,13 +1113,13 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("hours_per_week_spent", integer()))
 					.addColumn(new Column("weeks_spent", integer(), NOT_NULL))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("institute_name", varchar(255)))
 					.addColumn(new Column("country", varchar(255)))
 					.addColumn(new Column("city", varchar(255)));
 
 			Table occupations = new Table("occupations")
-					.addColumn(new Column("id", bigint(), AUTO_INCREMENT, NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), AUTO_INCREMENT, NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("student_id", bigint(), NOT_NULL))
 					.addColumn(new Column("started", date(), NOT_NULL))
 					.addColumn(new Column("abroad", bool(), "'false'", NOT_NULL))
@@ -1127,26 +1127,26 @@ public class GreedyMigrationPlannerTest {
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table studentHighSchools = new Table("student_high_schools")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("level", varchar(255)))
 					.addColumn(new Column("school_name", varchar(255)))
 					.addColumn(new Column("city", varchar(255), NOT_NULL))
 					.addColumn(new Column("country", varchar(255), NOT_NULL));
 
 			Table studentHigherEducations = new Table("student_higher_educations")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("aborted", bool(), "'false'"))
 					.addColumn(new Column("education_id", bigint()))
 					.addColumn(new Column("nominal_duration", integer(), NOT_NULL));
 
 			Table studentInterestedIndustries = new Table("student_interested_industries")
-					.addColumn(new Column("student_id", bigint(), IDENTITY))
+					.addColumn(new Column("student_id", bigint(), PRIMARY_KEY))
 					.addColumn(new Column("industries", varchar(255)))
 					.addColumn(new Column("created_at", timestamp(true), "'now()'"))
 					.addColumn(new Column("updated_at", timestamp(true)));
 
 			Table students = new Table("students")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("invited_by", bigint()))
 					.addColumn(new Column("magnets", integer(), "'0'", NOT_NULL))
 					.addColumn(new Column("main_experience_id", bigint()))
@@ -1156,11 +1156,11 @@ public class GreedyMigrationPlannerTest {
 
 			Table studentsEducations = new Table("students__educations")
 					.addColumn(new Column("gpa", floats()))
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("graduated", bool()));
 
 			Table users = new Table("users")
-					.addColumn(new Column("id", bigint(), NOT_NULL, IDENTITY))
+					.addColumn(new Column("id", bigint(), NOT_NULL, PRIMARY_KEY))
 					.addColumn(new Column("email", varchar(255), NOT_NULL))
 					.addColumn(new Column("first_name", varchar(255), NOT_NULL))
 					.addColumn(new Column("last_name", varchar(255), NOT_NULL))
@@ -1197,50 +1197,50 @@ public class GreedyMigrationPlannerTest {
 			Catalog catalog = new Catalog("test-db");
 
 			Table stores = new Table("stores")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("manager_id", integer(), NOT_NULL));
 
 			Table staff = new Table("staff")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("store_id", integer(), NOT_NULL));
 
 			Table customers = new Table("customers")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL))
 					.addColumn(new Column("store_id", integer(), NOT_NULL))
 					.addColumn(new Column("referred_by", integer()));
 
 			Table films = new Table("films")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 			Table inventory = new Table("inventory")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("store_id", integer(), NOT_NULL))
 					.addColumn(new Column("film_id", integer(), NOT_NULL));
 
 			Table paychecks = new Table("paychecks")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("staff_id", integer(), NOT_NULL))
-					.addColumn(new Column("date", date(), IDENTITY, NOT_NULL))
+					.addColumn(new Column("date", date(), PRIMARY_KEY, NOT_NULL))
 					.addColumn(new Column("amount", floats(), NOT_NULL));
 
 			Table payments = new Table("payments")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("staff_id", integer()))
 					.addColumn(new Column("customer_id", integer(), NOT_NULL))
 					.addColumn(new Column("rental_id", integer(), NOT_NULL))
-					.addColumn(new Column("date", date(), IDENTITY, NOT_NULL))
+					.addColumn(new Column("date", date(), PRIMARY_KEY, NOT_NULL))
 					.addColumn(new Column("amount", floats(), NOT_NULL));
 
 			Table rentals = new Table("rentals")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("staff_id", integer()))
 					.addColumn(new Column("customer_id", integer(), NOT_NULL))
 					.addColumn(new Column("inventory_id", integer(), NOT_NULL))
-					.addColumn(new Column("date", date(), IDENTITY, NOT_NULL));
+					.addColumn(new Column("date", date(), PRIMARY_KEY, NOT_NULL));
 
 			stores.addForeignKey("manager_id").referencing(staff, "id");
 
@@ -1280,29 +1280,29 @@ public class GreedyMigrationPlannerTest {
 			Catalog catalog = new Catalog("test-db");
 
 			Table users = new Table("users")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 			Table students = new Table("students")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("referred_by", integer()))
 					.addColumn(new Column("main_student_higher_education", integer()))
 					.addColumn(new Column("main_experience", integer()));
 
 			Table studentHigherEducations = new Table("student_higher_educations")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("student_education_id", integer(), NOT_NULL));
 
 			Table studentEducations = new Table("student_educations")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("resume_id", integer(), NOT_NULL));
 
 			Table experiences = new Table("experiences")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("resume_id", integer(), NOT_NULL));
 
 			Table resumes = new Table("resumes")
-					.addColumn(new Column("id", integer(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+					.addColumn(new Column("id", integer(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 					.addColumn(new Column("student_id", integer(), NOT_NULL));
 
 			students.addForeignKey("id").referencing(users, "id");
@@ -1434,7 +1434,7 @@ public class GreedyMigrationPlannerTest {
 	}
 
 	@Test
-	public void testThatIdentityColumnsAreMigratedFirst() {
+	public void testThatPrimaryKeyColumnsAreMigratedFirst() {
 		for (Step step : plan.getSteps()) {
 			Operation operation = step.getOperation();
 			if (operation.getType() != Type.COPY) {
@@ -1443,15 +1443,15 @@ public class GreedyMigrationPlannerTest {
 
 			Table table = operation.getTables().iterator().next();
 
-			List<Column> identityColumns = table.getIdentityColumns();
+			List<Column> primaryKeyColumns = table.getPrimaryKeyColumns();
 			Set<Column> columns = operation.getColumns().stream()
 					.map(table::getColumn)
 					.collect(Collectors.toSet());
 
-			if (!columns.containsAll(identityColumns)) {
+			if (!columns.containsAll(primaryKeyColumns)) {
 				Set<Step> dependencies = step.getTransitiveDependencies();
 
-				boolean migratesIdentities = false;
+				boolean migratesPrimaryKeys = false;
 				for (Step dependency : dependencies) {
 					Operation dependencyOperation = dependency.getOperation();
 					if (dependencyOperation.getType() != Type.COPY) {
@@ -1463,13 +1463,13 @@ public class GreedyMigrationPlannerTest {
 							.map(other::getColumn)
 							.collect(Collectors.toSet());
 
-					if (other.equals(table) && dependencyColumns.containsAll(identityColumns)) {
-						migratesIdentities = true;
+					if (other.equals(table) && dependencyColumns.containsAll(primaryKeyColumns)) {
+						migratesPrimaryKeys = true;
 						break;
 					}
 				}
 
-				collector.checkThat("Identities are not migrated first: " + table.getName(), migratesIdentities, is(true));
+				collector.checkThat("Primary keys are not migrated first: " + table.getName(), migratesPrimaryKeys, is(true));
 			}
 		}
 	}
@@ -1495,7 +1495,7 @@ public class GreedyMigrationPlannerTest {
 					continue;
 				}
 
-				Set<String> requiredIdentityColumns = table.getForeignKeys().stream()
+				Set<String> requiredPrimaryKeyColumns = table.getForeignKeys().stream()
 						.filter(ForeignKey::isNotNullable)
 						.filter(fk -> fk.getReferredTable().equals(requiresTable))
 						.flatMap(fk -> fk.getReferredColumns().stream())
@@ -1520,14 +1520,14 @@ public class GreedyMigrationPlannerTest {
 								.map(Column::getName)
 								.collect(Collectors.toSet());
 
-						if (dependencyColumns.containsAll(requiredIdentityColumns)) {
+						if (dependencyColumns.containsAll(requiredPrimaryKeyColumns)) {
 							satisfied = true;
 							break;
 						}
 					}
 				}
 
-				collector.checkThat("Identities of parent table: " + requiresTable.getName()
+				collector.checkThat("Primary keys of parent table: " + requiresTable.getName()
 						+ " should be migrated before copying records of: " + table.getName(), satisfied, is(true));
 			}
 		}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/SyncFunctionTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/planner/SyncFunctionTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.backends.planner;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.varchar;
@@ -35,11 +35,11 @@ public class SyncFunctionTest {
 	@Test
 	public void testSimpleDataMapping() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL))
 				.addColumn(new Column("email", varchar(255)));
 
@@ -76,11 +76,11 @@ public class SyncFunctionTest {
 	@Test
 	public void testDataMappingWithColumnRename() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("full_name", varchar(255), NOT_NULL));
 
 		Catalog catalog = new Catalog("public");
@@ -114,13 +114,13 @@ public class SyncFunctionTest {
 	}
 
 	@Test
-	public void testDataMappingWithColumnIdentityRename() {
+	public void testDataMappingWithColumnPrimaryKeyRename() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("user_id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("user_id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Catalog catalog = new Catalog("public");
@@ -156,11 +156,11 @@ public class SyncFunctionTest {
 	@Test
 	public void testDataMappingWhereColumnIsMadeNonNullable() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255)));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255), NOT_NULL));
 
 		Catalog catalog = new Catalog("public");
@@ -194,16 +194,16 @@ public class SyncFunctionTest {
 	@Test
 	public void testDataMappingWithNonNullableForeignKey() {
 		Table original = new Table("users")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("other_id", bigint(), NOT_NULL))
 				.addColumn(new Column("name", varchar(255)));
 
 		Table other = new Table("other")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("name", varchar(255)));
 
 		Table ghost = new Table("users2")
-				.addColumn(new Column("id", bigint(), IDENTITY, AUTO_INCREMENT, NOT_NULL))
+				.addColumn(new Column("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT, NOT_NULL))
 				.addColumn(new Column("other_id", bigint(), NOT_NULL))
 				.addColumn(new Column("full_name", varchar(255), NOT_NULL));
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/versioning/BackendTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/versioning/BackendTest.java
@@ -1,7 +1,7 @@
 package io.quantumdb.core.versioning;
 
 import static io.quantumdb.core.schema.definitions.Column.Hint.AUTO_INCREMENT;
-import static io.quantumdb.core.schema.definitions.Column.Hint.IDENTITY;
+import static io.quantumdb.core.schema.definitions.Column.Hint.PRIMARY_KEY;
 import static io.quantumdb.core.schema.definitions.Column.Hint.NOT_NULL;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bigint;
 import static io.quantumdb.core.schema.definitions.PostgresTypes.bool;
@@ -46,10 +46,10 @@ public class BackendTest {
 		Catalog catalog = new Catalog("public")
 				.addSequence(sequence)
 				.addTable(new Table("table_1")
-						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, IDENTITY))
+						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, PRIMARY_KEY))
 						.addColumn(new Column("name", text(), NOT_NULL)))
 				.addTable(new Table("table_2")
-						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, IDENTITY))
+						.addColumn(new Column("id", bigint(), sequence, AUTO_INCREMENT, PRIMARY_KEY))
 						.addColumn(new Column("name", text(), NOT_NULL))
 						.addColumn(new Column("admin", bool(), "false", NOT_NULL)));
 


### PR DESCRIPTION
Since PostgreSQL 10 an identity column is actually an auto incrementing column.

I decided to not touch the class Identity as I am not 100% sure what it exactly does and just changing it to PrimaryKey would be wrong. I think it keeps track of which primary key column is at which value during the migration process but I am not sure.