### PR TITLE
Support table and column names with uppercase characters

### DIFF
--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
@@ -1,5 +1,6 @@
 package io.quantumdb.core.planner;
 
+import static io.quantumdb.core.planner.QueryUtils.quoted;
 import static io.quantumdb.core.schema.definitions.ForeignKey.Action.CASCADE;
 import static io.quantumdb.core.schema.definitions.ForeignKey.Action.NO_ACTION;
 import static io.quantumdb.core.schema.definitions.ForeignKey.Action.RESTRICT;
@@ -36,7 +37,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class CatalogLoader {
 
-	private static final Pattern SEQUENCE_EXPRESSION = Pattern.compile("nextval\\(\\'(\\w+_id_seq)\\'::regclass\\)", Pattern.CASE_INSENSITIVE);
+	private static final Pattern SEQUENCE_EXPRESSION = Pattern.compile("nextval\\(\\'\"?(\\w+_id_seq)\"?\\'::regclass\\)", Pattern.CASE_INSENSITIVE);
 
 	static Catalog load(Connection connection, String catalogName) throws SQLException {
 		Catalog catalog = new Catalog(catalogName);
@@ -174,7 +175,7 @@ class CatalogLoader {
 				.append("FROM pg_index, pg_class, pg_attribute, pg_namespace ")
 				.append("WHERE ")
 				.append("  nspname = 'public' AND ")
-				.append("  pg_class.oid = '\"" + tableName + "\"'::regclass AND ")
+				.append("  pg_class.oid = '" + quoted(tableName) + "'::regclass AND ")
 				.append("  indrelid = pg_class.oid AND ")
 				.append("  pg_class.relnamespace = pg_namespace.oid AND ")
 				.append("  pg_attribute.attrelid = pg_class.oid AND ")

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/QueryUtils.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/QueryUtils.java
@@ -1,0 +1,19 @@
+package io.quantumdb.core.planner;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QueryUtils {
+
+	public static String quoted(String input) {
+		if (input == null) {
+			return null;
+		}
+		else if (input.length() >= 2 && input.charAt(0) == '\"' && input.charAt(input.length() - 1) == '\"') {
+			return input;
+		}
+		return "\"" + input + "\"";
+	}
+
+}

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -1,5 +1,7 @@
 package io.quantumdb.core.planner;
 
+import static io.quantumdb.core.planner.QueryUtils.quoted;
+
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -72,14 +74,14 @@ class TableDataMigrator {
 
 				QueryBuilder migrator = new QueryBuilder();
 				if (lastProcessedId.isEmpty()) {
-					migrator.append("SELECT * FROM " + initialMigrator.getName() + "();");
+					migrator.append("SELECT * FROM " + quoted(initialMigrator.getName()) + "();");
 				}
 				else {
 					List<String> values = successiveMigrator.getParameters().stream()
 							.map(parameterName -> asExpression(lastProcessedId.get(stripEscaping(parameterName))))
 							.collect(Collectors.toList());
 
-					migrator.append("SELECT * FROM " + successiveMigrator.getName() + "(")
+					migrator.append("SELECT * FROM " + quoted(successiveMigrator.getName()) + "(")
 							.append(Joiner.on(", ").join(values) + ");");
 				}
 
@@ -128,9 +130,9 @@ class TableDataMigrator {
 		try (Connection connection = backend.connect()) {
 			try (Statement statement = connection.createStatement()) {
 				String query = new QueryBuilder()
-						.append("SELECT " + Joiner.on(", ").join(primaryKeyColumns))
-						.append("FROM " + from.getName())
-						.append("ORDER BY " + Joiner.on(" DESC, ").join(primaryKeyColumns) + " DESC")
+						.append("SELECT " + primaryKeyColumns.stream().map(QueryUtils::quoted).collect(Collectors.joining(", ")))
+						.append("FROM " + quoted(from.getName()))
+						.append("ORDER BY " + primaryKeyColumns.stream().map(value -> quoted(value) + " DESC").collect(Collectors.joining(", ")))
 						.append("LIMIT 1")
 						.toString();
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/SyncFunctionTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/SyncFunctionTest.java
@@ -1,0 +1,65 @@
+package io.quantumdb.core.planner;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import com.google.common.collect.Sets;
+import io.quantumdb.core.backends.PostgresqlDatabase;
+import io.quantumdb.core.schema.definitions.Catalog;
+import io.quantumdb.core.schema.definitions.Column;
+import io.quantumdb.core.schema.definitions.Column.Hint;
+import io.quantumdb.core.schema.definitions.PostgresTypes;
+import io.quantumdb.core.schema.definitions.Table;
+import io.quantumdb.core.versioning.RefLog;
+import io.quantumdb.core.versioning.RefLog.ColumnRef;
+import io.quantumdb.core.versioning.RefLog.TableRef;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SyncFunctionTest {
+
+	@Rule
+	public final PostgresqlDatabase database = new PostgresqlDatabase();
+
+	@Test
+	public void createSimpleSyncFunction() {
+		RefLog refLog = new RefLog();
+		Version v1 = new Version("v1", null);
+		Version v2 = new Version("v2", v1);
+
+		TableRef t1 = refLog.addTable("users", "table_a", v1,
+				new ColumnRef("id"),
+				new ColumnRef("name"));
+
+		TableRef t2 = refLog.addTable("users", "table_b", v2,
+				new ColumnRef("id", t1.getColumn("id")),
+				new ColumnRef("name", t1.getColumn("name")));
+
+		Catalog catalog = new Catalog(database.getCatalogName());
+
+		catalog.addTable(new Table("table_a")
+				.addColumn(new Column("id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT))
+				.addColumn(new Column("name", PostgresTypes.bigint(), Hint.NOT_NULL)));
+
+		catalog.addTable(new Table("table_b")
+				.addColumn(new Column("id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT))
+				.addColumn(new Column("name", PostgresTypes.bigint(), Hint.NOT_NULL)));
+
+		NullRecords nullRecords = new NullRecords();
+
+		Map<ColumnRef, ColumnRef> columnMapping = refLog.getColumnMapping(t1, t2);
+		SyncFunction function = new SyncFunction(refLog, t1, t2, columnMapping, catalog, nullRecords,
+				"migrate_data", "migration_trigger");
+
+		function.setColumnsToMigrate(Sets.newHashSet("id", "name"));
+
+		String createFunctionStatement = function.createFunctionStatement().toString();
+		String createTriggerStatement = function.createTriggerStatement().toString();
+
+		assertEquals(createFunctionStatement, "CREATE OR REPLACE FUNCTION \"migrate_data\"() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); ELSIF TG_OP = 'UPDATE' THEN LOOP UPDATE \"table_b\" SET \"id\" = NEW.\"id\" WHERE \"id\" = OLD.\"id\"; IF found THEN EXIT; END IF; BEGIN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); EXIT; EXCEPTION WHEN unique_violation THEN END; END LOOP; ELSIF TG_OP = 'DELETE' THEN DELETE FROM \"table_b\" WHERE \"id\" = OLD.\"id\"; END IF; RETURN NEW; END; $$ LANGUAGE 'plpgsql';");
+		assertEquals(createTriggerStatement, "CREATE TRIGGER \"migration_trigger\" AFTER INSERT OR UPDATE OR DELETE ON \"table_a\" FOR EACH ROW WHEN (pg_trigger_depth() = 0) EXECUTE PROCEDURE \"migrate_data\"();");
+	}
+
+}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/TableCreatorTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/TableCreatorTest.java
@@ -1,0 +1,205 @@
+package io.quantumdb.core.planner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.quantumdb.core.backends.PostgresqlDatabase;
+import io.quantumdb.core.schema.definitions.Catalog;
+import io.quantumdb.core.schema.definitions.Column;
+import io.quantumdb.core.schema.definitions.Column.Hint;
+import io.quantumdb.core.schema.definitions.ForeignKey;
+import io.quantumdb.core.schema.definitions.Index;
+import io.quantumdb.core.schema.definitions.PostgresTypes;
+import io.quantumdb.core.schema.definitions.Table;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TableCreatorTest {
+
+	@Rule
+	public final PostgresqlDatabase database = new PostgresqlDatabase();
+
+	private final TableCreator tableCreator = new TableCreator();
+
+	@Test
+	public void testCreatingSimpleTable() throws SQLException {
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = new Catalog(database.getCatalogName());
+			Table users = new Table("users")
+					.addColumn(new Column("id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT))
+					.addColumn(new Column("name", PostgresTypes.text(), Hint.NOT_NULL));
+
+			catalog.addTable(users);
+
+			tableCreator.create(connection, Lists.newArrayList(users));
+		}
+
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = CatalogLoader.load(connection, database.getCatalogName());
+			Table users = catalog.getTable("users");
+
+			Column id = users.getColumn("id");
+			assertEquals(Sets.newHashSet(Hint.PRIMARY_KEY, Hint.NOT_NULL, Hint.AUTO_INCREMENT), id.getHints());
+			assertEquals(PostgresTypes.bigint(), id.getType());
+			assertEquals("users_id_seq", id.getSequence().getName());
+			assertNull(id.getDefaultValue());
+			assertNull(id.getOutgoingForeignKey());
+
+			Column name = users.getColumn("name");
+			assertEquals(Sets.newHashSet(Hint.NOT_NULL), name.getHints());
+			assertEquals(PostgresTypes.text(), name.getType());
+			assertNull(name.getSequence());
+			assertNull(name.getDefaultValue());
+			assertNull(name.getOutgoingForeignKey());
+		}
+	}
+
+	@Test
+	public void testCreatingTableWithDefaultValues() throws SQLException {
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = new Catalog(database.getCatalogName());
+			Table users = new Table("users")
+					.addColumn(new Column("id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT))
+					.addColumn(new Column("active", PostgresTypes.bool(), "true", Hint.NOT_NULL));
+
+			catalog.addTable(users);
+
+			tableCreator.create(connection, Lists.newArrayList(users));
+		}
+
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = CatalogLoader.load(connection, database.getCatalogName());
+			Table users = catalog.getTable("users");
+
+			Column id = users.getColumn("id");
+			assertEquals(Sets.newHashSet(Hint.PRIMARY_KEY, Hint.NOT_NULL, Hint.AUTO_INCREMENT), id.getHints());
+			assertEquals(PostgresTypes.bigint(), id.getType());
+			assertEquals("users_id_seq", id.getSequence().getName());
+			assertNull(id.getDefaultValue());
+			assertNull(id.getOutgoingForeignKey());
+
+			Column name = users.getColumn("active");
+			assertEquals(Sets.newHashSet(Hint.NOT_NULL), name.getHints());
+			assertEquals(PostgresTypes.bool(), name.getType());
+			assertNull(name.getSequence());
+			assertEquals("true", name.getDefaultValue());
+			assertNull(name.getOutgoingForeignKey());
+		}
+	}
+
+	@Test
+	public void testCreatingTableWithUppercaseCharacters() throws SQLException {
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = new Catalog(database.getCatalogName());
+			Table users = new Table("Users")
+					.addColumn(new Column("Id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT))
+					.addColumn(new Column("Name", PostgresTypes.text(), Hint.NOT_NULL));
+
+			catalog.addTable(users);
+
+			tableCreator.create(connection, Lists.newArrayList(users));
+		}
+
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = CatalogLoader.load(connection, database.getCatalogName());
+			Table users = catalog.getTable("Users");
+
+			Column id = users.getColumn("Id");
+			assertEquals(Sets.newHashSet(Hint.PRIMARY_KEY, Hint.NOT_NULL, Hint.AUTO_INCREMENT), id.getHints());
+			assertEquals(PostgresTypes.bigint(), id.getType());
+			assertEquals("Users_Id_seq", id.getSequence().getName());
+			assertNull(id.getDefaultValue());
+			assertNull(id.getOutgoingForeignKey());
+
+			Column name = users.getColumn("Name");
+			assertEquals(Sets.newHashSet(Hint.NOT_NULL), name.getHints());
+			assertEquals(PostgresTypes.text(), name.getType());
+			assertNull(name.getSequence());
+			assertNull(name.getDefaultValue());
+			assertNull(name.getOutgoingForeignKey());
+		}
+	}
+
+	@Test
+	public void testCreatingTableWithIndices() throws SQLException {
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = new Catalog(database.getCatalogName());
+			Table users = new Table("users")
+					.addColumn(new Column("id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT))
+					.addColumn(new Column("email", PostgresTypes.text(), Hint.NOT_NULL))
+					.addIndex(new Index("email_idx", Lists.newArrayList("email"), true));
+
+			catalog.addTable(users);
+
+			tableCreator.create(connection, Lists.newArrayList(users));
+		}
+
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = CatalogLoader.load(connection, database.getCatalogName());
+			Table users = catalog.getTable("users");
+
+			Column id = users.getColumn("id");
+			assertEquals(Sets.newHashSet(Hint.PRIMARY_KEY, Hint.NOT_NULL, Hint.AUTO_INCREMENT), id.getHints());
+			assertEquals(PostgresTypes.bigint(), id.getType());
+			assertEquals("users_id_seq", id.getSequence().getName());
+			assertNull(id.getDefaultValue());
+			assertNull(id.getOutgoingForeignKey());
+
+			Column email = users.getColumn("email");
+			assertEquals(Sets.newHashSet(Hint.NOT_NULL), email.getHints());
+			assertEquals(PostgresTypes.text(), email.getType());
+			assertNull(email.getSequence());
+			assertNull(email.getDefaultValue());
+			assertNull(email.getOutgoingForeignKey());
+
+			Index index = users.getIndex("email");
+			assertEquals("email_idx", index.getIndexName());
+			assertEquals(Lists.newArrayList("email"), index.getColumns());
+			assertTrue(index.isUnique());
+		}
+	}
+
+	@Test
+	public void testCreatingTableWithForeignKeys() throws SQLException {
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = new Catalog(database.getCatalogName());
+			Table users = new Table("users")
+					.addColumn(new Column("id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT))
+					.addColumn(new Column("name", PostgresTypes.text(), Hint.NOT_NULL));
+
+			Table messages = new Table("messages")
+					.addColumn(new Column("id", PostgresTypes.bigint(), Hint.PRIMARY_KEY, Hint.AUTO_INCREMENT))
+					.addColumn(new Column("author_id", PostgresTypes.bigint(), Hint.NOT_NULL))
+					.addColumn(new Column("content", PostgresTypes.text(), Hint.NOT_NULL));
+
+			messages.addForeignKey("author_id")
+					.referencing(users, "id");
+
+			catalog.addTable(users);
+			catalog.addTable(messages);
+
+			tableCreator.create(connection, Lists.newArrayList(users, messages));
+		}
+
+		try (Connection connection = database.createConnection()) {
+			Catalog catalog = CatalogLoader.load(connection, database.getCatalogName());
+			Table messages = catalog.getTable("messages");
+
+			assertEquals(1, messages.getForeignKeys().size());
+			ForeignKey foreignKey = messages.getForeignKeys().get(0);
+
+			assertEquals("users", foreignKey.getReferredTableName());
+			assertEquals(Lists.newArrayList("id"), foreignKey.getReferredColumns());
+
+			assertEquals("messages", foreignKey.getReferencingTableName());
+			assertEquals(Lists.newArrayList("author_id"), foreignKey.getReferencingColumns());
+		}
+	}
+
+}


### PR DESCRIPTION
This PR adds support to the `quantumdb-postgresql` module for dealing with uppercase characters in table and column names.

We achieve this by double quoting names specified by the user, but like other ORMs (Hibernate, JOOQ, etc) and schema versioners (Liquibase, etc) do.

This also adds tests for `TableCreator` and `SyncFunction`. Some of the other changed files could benefit from tests as well, but it would be easier if we could intercept their constructed queries. Linking to #65 as this is related.