### PR TITLE
Avoid printing logs to screen when using the CLI.

### DIFF
--- a/quantumdb-cli/src/main/resources/logback.xml
+++ b/quantumdb-cli/src/main/resources/logback.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration scan="true" scanPeriod="30 seconds">
 
+	<!-- Stop output INFO at start -->
+	<statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
 	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<file>logs/cli.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
@@ -383,21 +383,6 @@ public class Backend {
 			while (resultSet.next()) {
 				String refId = resultSet.getString("ref_id");
 				if (!refIds.remove(refId)) {
-					try (Statement stmt = connection.createStatement()) {
-						ResultSet r = stmt.executeQuery("SELECT * FROM quantumdb.column_mappings");
-						printResults(r);
-					}
-
-					try (Statement stmt = connection.createStatement()) {
-						ResultSet r = stmt.executeQuery("SELECT * FROM quantumdb.table_columns");
-						printResults(r);
-					}
-
-					try (Statement stmt = connection.createStatement()) {
-						ResultSet r = stmt.executeQuery("SELECT * FROM quantumdb.refs");
-						printResults(r);
-					}
-
 					try (PreparedStatement delete = connection.prepareStatement(deleteQuery)) {
 						delete.setString(1, refId);
 						delete.execute();


### PR DESCRIPTION
This addresses two issues:

- Logback logging to console when using the CLI.
- A bunch of debug logging being printed with dropping a specific non-empty version using `quantumdb drop <id>`.