### PR TITLE
Ensure changeset id is printed if no description is defined when running 'quantumdb status'.

### DIFF
--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Command.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Command.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import io.quantumdb.cli.utils.CliException;
@@ -74,13 +75,19 @@ public abstract class Command {
 
 		for (Version version : refLog.getVersions()) {
 			ChangeSet changeSet = version.getChangeSet();
-			writer.write(version.getId() + ": " + changeSet.getDescription(), Context.SUCCESS);
+			String description = Optional.ofNullable(changeSet.getDescription())
+					.orElse(changeSet.getId());
+
+			writer.write(version.getId() + ": " + description, Context.SUCCESS);
 		}
 
 		if (refLog.getVersions().isEmpty()) {
 			Version version = changelog.getRoot();
 			ChangeSet changeSet = version.getChangeSet();
-			writer.write(version.getId() + ": " + changeSet.getDescription(), Context.SUCCESS);
+			String description = Optional.ofNullable(changeSet.getDescription())
+					.orElse(changeSet.getId());
+
+			writer.write(version.getId() + ": " + description, Context.SUCCESS);
 		}
 
 		writer.indent(-1);


### PR DESCRIPTION
When no description is defined in the `changelog.xml` file for a given changeset, when that changeset is present in the output of `quantumdb status` it only lists the associated version with that changeset, and no further information. We could probably improve on this, but for now simply printing the id of the changeset when no description is set will do.