### PR TITLE
New drop logic

### DIFF
--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Drop.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Drop.java
@@ -74,7 +74,7 @@ public class Drop extends Command {
 
 			writer.write("Dropping database schema version: " + version.getId() + "...");
 
-			backend.getMigrator().drop(state, version);
+			backend.getMigrator().drop(state, version, null);
 
 			if (isDryRun) {
 				if (printDryRun) {

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/DatabaseMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/DatabaseMigrator.java
@@ -39,6 +39,6 @@ public interface DatabaseMigrator {
 	 * @param version The version of the database schema to drop.
 	 * @throws MigrationException In case something prevented the drop.
 	 */
-	void drop(State state, Version version) throws MigrationException;
+	void drop(State state, Version version, Stage stage) throws MigrationException;
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
@@ -97,7 +97,7 @@ public class Migrator {
 				migrator.applySchemaChanges(state, stage.getParent(), stage.getLast());
 				if (intermediate != null) {
 					log.info("Dropping intermediate state: {}", intermediate.getId());
-					migrator.drop(state, intermediate);
+					migrator.drop(state, intermediate, stage);
 				}
 				intermediate = stage.getLast();
 			}
@@ -115,7 +115,7 @@ public class Migrator {
 		Changelog changelog = state.getChangelog();
 		Version version = changelog.getVersion(versionId);
 
-		migrator.drop(state, version);
+		migrator.drop(state, version, null);
 	}
 
 	private State loadState() throws MigrationException {

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -333,7 +334,7 @@ class CatalogLoader {
 					parser.consume();
 				}
 
-				List<String> groups = parser.consumeGroup('(', ')', ',');
+				List<String> groups = parser.consumeGroup('(', ')', ',').stream().map(String::trim).collect(Collectors.toList());
 				// TODO: Add support for expressions. Now we only support column references.
 
 				Table table = catalog.getTable(indexTableName);

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
@@ -145,7 +145,7 @@ public class SelectiveMigratorFunction {
 		createStatement.append("		  WHERE  " + primaryKeyCondition + ";");
 		createStatement.append("	  EXCEPTION WHEN unique_violation THEN END;");
 		createStatement.append("	END LOOP;");
-		createStatement.append("  RETURN CONCAT('(', " + primaryKeyColumnNames.stream().map(value -> "r." + quoted(value)).collect(Collectors.joining(", ")) + ", ')');");
+		createStatement.append("  RETURN CONCAT('(', " + primaryKeyColumnNames.stream().map(value -> "r." + quoted(value)).collect(Collectors.joining(",',', ")) + ", ')');");
 		createStatement.append("END; $$ LANGUAGE 'plpgsql';");
 
 		QueryBuilder dropStatement = new QueryBuilder();
@@ -269,7 +269,7 @@ public class SelectiveMigratorFunction {
 		createStatement.append("		  VALUES (" + Joiner.on(", ").join(values.values()) + ");");
 		createStatement.append("	  EXCEPTION WHEN unique_violation THEN END;");
 		createStatement.append("	END LOOP;");
-		createStatement.append("  RETURN CONCAT('(', " + primaryKeyColumnNames.stream().map(value -> "r." + quoted(value)).collect(Collectors.joining(", ")) + ", ')');");
+		createStatement.append("  RETURN CONCAT('(', " + primaryKeyColumnNames.stream().map(value -> "r." + quoted(value)).collect(Collectors.joining(",',', ")) + ", ')');");
 		createStatement.append("END; $$ LANGUAGE 'plpgsql';");
 
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
@@ -62,7 +62,7 @@ public class TableCreator {
 				queryBuilder.append(", ");
 			}
 
-			queryBuilder.append("\"" + column.getName() + "\" " + column.getType());
+			queryBuilder.append(quoted(column.getName()) + " " + column.getType());
 			if (column.isNotNull()) {
 				queryBuilder.append("NOT NULL");
 			}

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -196,6 +196,22 @@ class TableDataMigrator {
 				right = new BigDecimal((Long) right);
 			}
 
+			if (left instanceof Double) {
+				left = BigDecimal.valueOf((Double) left);
+			}
+
+			if (right instanceof Double) {
+				right = BigDecimal.valueOf((Double) right);
+			}
+
+			if (left instanceof Float) {
+				left = BigDecimal.valueOf((Float) left);
+			}
+
+			if (right instanceof Float) {
+				right = BigDecimal.valueOf((Float) right);
+			}
+
 			Comparable leftComparable = (Comparable) left;
 			Comparable rightComparable = (Comparable) right;
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -5,11 +5,11 @@ import static io.quantumdb.core.planner.QueryUtils.quoted;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -245,10 +245,15 @@ class TableDataMigrator {
 
 		switch (type) {
 			case SMALLINT:
+				return Short.parseShort(value);
 			case INTEGER:
+				return Integer.parseInt(value);
 			case BIGINT:
+				return Long.parseLong(value);
 			case FLOAT:
+				return Float.parseFloat(value);
 			case DOUBLE:
+				return Double.parseDouble(value);
 			case NUMERIC:
 				return new BigDecimal(value);
 			case BOOLEAN:
@@ -259,9 +264,9 @@ class TableDataMigrator {
 			case OID:
 				return value;
 			case DATE:
-				return Date.parse(value);
+				return Date.valueOf(value);
 			case TIMESTAMP:
-				return Timestamp.parse(value);
+				return Timestamp.valueOf(value);
 			case UUID:
 			default:
 				return UUID.fromString(value);

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -188,30 +188,6 @@ class TableDataMigrator {
 				right = right.toString().toLowerCase();
 			}
 
-			if (left instanceof Long) {
-				left = new BigDecimal((Long) left);
-			}
-
-			if (right instanceof Long) {
-				right = new BigDecimal((Long) right);
-			}
-
-			if (left instanceof Double) {
-				left = BigDecimal.valueOf((Double) left);
-			}
-
-			if (right instanceof Double) {
-				right = BigDecimal.valueOf((Double) right);
-			}
-
-			if (left instanceof Float) {
-				left = BigDecimal.valueOf((Float) left);
-			}
-
-			if (right instanceof Float) {
-				right = BigDecimal.valueOf((Float) right);
-			}
-
 			Comparable leftComparable = (Comparable) left;
 			Comparable rightComparable = (Comparable) right;
 
@@ -270,11 +246,11 @@ class TableDataMigrator {
 		switch (type) {
 			case SMALLINT:
 			case INTEGER:
-				return Integer.parseInt(value);
 			case BIGINT:
-				return Long.parseLong(value);
+			case FLOAT:
+			case DOUBLE:
 			case NUMERIC:
-				return Double.parseDouble(value);
+				return new BigDecimal(value);
 			case BOOLEAN:
 				return Boolean.parseBoolean(value);
 			case TEXT:
@@ -284,8 +260,6 @@ class TableDataMigrator {
 				return value;
 			case DATE:
 				return Date.parse(value);
-			case FLOAT:
-				return Float.parseFloat(value);
 			case TIMESTAMP:
 				return Timestamp.parse(value);
 			case UUID:

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/schema/definitions/PostgresTypes.java
@@ -187,7 +187,7 @@ public class PostgresTypes {
 
 	public static ColumnType smallserial() {
 		return new ColumnType(ColumnType.Type.SMALLINT, false, "smallserial", () -> 0,
-				(statement, position, value) -> statement.setInt(position, ((Number) value).intValue()));
+				(statement, position, value) -> statement.setShort(position, ((Number) value).shortValue()));
 	}
 
 	public static ColumnType serial() {
@@ -202,7 +202,7 @@ public class PostgresTypes {
 
 	public static ColumnType smallint() {
 		return new ColumnType(ColumnType.Type.SMALLINT, false, "smallint", () -> 0,
-				(statement, position, value) -> statement.setInt(position, ((Number) value).intValue()));
+				(statement, position, value) -> statement.setShort(position, ((Number) value).shortValue()));
 	}
 
 	public static ColumnType integer() {


### PR DESCRIPTION
I have not tested this one yet (planning on this weekend), but I think this is how the drop logic should be. 
The previous logic I had was not right, as the drop method was also used in the migration step to drop intermediate versions.

It basically looks at if the TableRefs of the version to drop is also present in any other active version (excluding the version to drop) but including the latest intermediate version (you do not want to drop that one just yet). If it is not part of any active version it then checks if the table is still present in the database, otherwise you will drop a table that does not exist anymore.