### PR TITLE
Cleanup

### DIFF
--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/Main.java
@@ -11,6 +11,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.quantumdb.cli.commands.Changelog;
+import io.quantumdb.cli.commands.Cleanup;
 import io.quantumdb.cli.commands.Command;
 import io.quantumdb.cli.commands.Command.Identifier;
 import io.quantumdb.cli.commands.Drop;
@@ -67,7 +68,8 @@ public class Main {
 				new Fork(),
 				new Nuke(),
 				new Drop(),
-				new Query()
+				new Query(),
+				new Cleanup()
 		);
 
 		LinkedHashMap<String, Command> result = Maps.newLinkedHashMap();

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Changelog.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Changelog.java
@@ -75,7 +75,6 @@ public class Changelog extends Command {
 
 	private void print(CliWriter writer, ChangeSet changeSet, Set<Version> activeVersions, boolean printShort) {
 		Version pointer = changeSet.getVersion();
-		Version lastVersion = pointer;
 		boolean active = activeVersions.contains(pointer);
 
 		int operations = 0;

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Changelog.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Changelog.java
@@ -47,7 +47,7 @@ public class Changelog extends Command {
 				Version version = versions.remove(0);
 				ChangeSet currentChangeset = version.getChangeSet();
 
-				if (version.getId().equals(from)) {
+				if (currentChangeset.getId().equals(from)) {
 					print = true;
 				}
 
@@ -56,7 +56,7 @@ public class Changelog extends Command {
 					limit--;
 				}
 
-				if (version.getId().equals(until) || limit <= 0) {
+				if (currentChangeset.getId().equals(until) || limit <= 0) {
 					print = false;
 				}
 
@@ -86,11 +86,13 @@ public class Changelog extends Command {
 			pointer = pointer.getParent();
 		}
 
-		String id = lastVersion.getId();
+		String id = changeSet.getId();
 		if (active) {
 			id += " (active)";
 		}
-		id += " - " + changeSet.getId();
+		if (changeSet.getDescription() != null) {
+			id += " - " + changeSet.getDescription();
+		}
 
 		writer.setIndent(0);
 		writer.write(id, Context.SUCCESS);

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Cleanup.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Cleanup.java
@@ -1,6 +1,5 @@
 package io.quantumdb.cli.commands;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.quantumdb.core.schema.operations.SchemaOperations.cleanupTables;
 
 import java.io.File;
@@ -9,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import io.quantumdb.cli.utils.CliException;
 import io.quantumdb.cli.utils.CliWriter;
 import io.quantumdb.cli.utils.CliWriter.Context;
@@ -41,8 +39,6 @@ public class Cleanup extends Command {
 
 			State state = loadState(backend);
 			Changelog changelog = state.getChangelog();
-
-			checkArgument(state.getRefLog().getVersions().size() == 1, "You may only call this command if you have 1 active version.");
 
 			Version last = changelog.getVersion(state.getRefLog().getVersions().toArray(new Version[0])[0].getId());
 			writer.write(last.getId());
@@ -86,22 +82,6 @@ public class Cleanup extends Command {
 			log.error(e.getMessage(), e);
 			writer.write(e.getMessage(), Context.FAILURE);
 		}
-	}
-
-	private Version getOriginVersion(List<String> arguments, State state, Changelog changelog) {
-		String versionId = getArgument(arguments, "from", String.class, () -> {
-			List<Version> versions = Lists.newArrayList(state.getRefLog().getVersions());
-			if (versions.isEmpty()) {
-				versions.add(changelog.getRoot());
-			}
-
-			if (versions.size() == 1) {
-				return versions.get(0).getId();
-			}
-			throw new CliException("You must specify a version to fork from!");
-		});
-
-		return changelog.getVersion(versionId);
 	}
 
 }

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Cleanup.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Cleanup.java
@@ -66,7 +66,7 @@ public class Cleanup extends Command {
 			writer.write("Renaming all tables back to their original name.");
 
 			Migrator migrator = new Migrator(backend);
-			migrator.migrate(last.getId(), changelog.getLastAdded().getId());
+			migrator.migrate(state, last.getId(), changelog.getLastAdded().getId());
 
 			if (isDryRun) {
 				if (printDryRun) {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Cleanup.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Cleanup.java
@@ -66,7 +66,7 @@ public class Cleanup extends Command {
 			writer.write("Renaming all tables back to their original name.");
 
 			Migrator migrator = new Migrator(backend);
-			migrator.migrate(state, last.getId(), changelog.getLastAdded().getId());
+			migrator.migrate(last.getId(), changelog.getLastAdded().getId());
 
 			if (isDryRun) {
 				if (printDryRun) {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Command.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Command.java
@@ -78,7 +78,7 @@ public abstract class Command {
 			String description = Optional.ofNullable(changeSet.getDescription())
 					.orElse(changeSet.getId());
 
-			writer.write(version.getId() + ": " + description, Context.SUCCESS);
+			writer.write(changeSet.getId() + ": " + description, Context.SUCCESS);
 		}
 
 		if (refLog.getVersions().isEmpty()) {
@@ -87,7 +87,7 @@ public abstract class Command {
 			String description = Optional.ofNullable(changeSet.getDescription())
 					.orElse(changeSet.getId());
 
-			writer.write(version.getId() + ": " + description, Context.SUCCESS);
+			writer.write(changeSet.getId() + ": " + description, Context.SUCCESS);
 		}
 
 		writer.indent(-1);

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Command.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Command.java
@@ -39,7 +39,7 @@ public abstract class Command {
 
 	void persistChanges(Backend backend, State state) {
 		try {
-			backend.persistState(state);
+			backend.persistState(state, null);
 		}
 		catch (SQLException e) {
 			log.error(e.getMessage(), e);

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Drop.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Drop.java
@@ -35,8 +35,12 @@ public class Drop extends Command {
 			State state = loadState(backend);
 			Changelog changelog = state.getChangelog();
 
-			String versionId = arguments.remove(0);
-			Version version = changelog.getVersion(versionId);
+			String changeSetId = arguments.remove(0);
+			Version version = changelog.getRoot();
+			while (!version.getChangeSet().getId().equals(changeSetId)) {
+				version = version.getChild();
+			}
+			version = version.getChangeSet().getVersion();
 
 			String outputFile = null;
 			boolean printDryRun = false;
@@ -56,7 +60,7 @@ public class Drop extends Command {
 			}
 
 			if (!isDryRun) {
-				writer.write("Checking how many clients are still connected to: " + version.getId());
+				writer.write("Checking how many clients are still connected to: " + version.getChangeSet().getId());
 				int count = backend.countClientsConnectedToVersion(version);
 
 				if (count > 0) {
@@ -72,7 +76,7 @@ public class Drop extends Command {
 				}
 			}
 
-			writer.write("Dropping database schema version: " + version.getId() + "...");
+			writer.write("Dropping database schema version: " + version.getChangeSet().getId() + "...");
 
 			backend.getMigrator().drop(state, version);
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Drop.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Drop.java
@@ -39,6 +39,9 @@ public class Drop extends Command {
 			Version version = changelog.getRoot();
 			while (!version.getChangeSet().getId().equals(changeSetId)) {
 				version = version.getChild();
+				if (version == null) {
+					throw new IllegalArgumentException("Please specify a valid Changeset ID to drop!");
+				}
 			}
 			version = version.getChangeSet().getVersion();
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Fork.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Fork.java
@@ -68,7 +68,7 @@ public class Fork extends Command {
 			writer.write("Forking database from: " + from.getId() + " to: " + to.getId() + "...");
 
 			Migrator migrator = new Migrator(backend);
-			migrator.migrate(from.getId(), to.getId());
+			migrator.migrate(state, from.getId(), to.getId());
 
 			if (isDryRun) {
 				if (printDryRun) {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Fork.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Fork.java
@@ -42,6 +42,9 @@ public class Fork extends Command {
 			Version version = changelog.getRoot();
 			while (!version.getChangeSet().getId().equals(toChangeSet)) {
 				version = version.getChild();
+				if (version == null) {
+					throw new IllegalArgumentException("Please specify a valid Changeset ID to fork to!");
+				}
 			}
 			Version to = version.getChangeSet().getVersion();
 
@@ -65,7 +68,7 @@ public class Fork extends Command {
 			writer.write("Forking database from: " + from.getId() + " to: " + to.getId() + "...");
 
 			Migrator migrator = new Migrator(backend);
-			migrator.migrate(state, from.getId(), to.getId());
+			migrator.migrate(from.getId(), to.getId());
 
 			if (isDryRun) {
 				if (printDryRun) {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
@@ -197,14 +197,14 @@ public class Query extends Command {
 			if (versions.size() == 1) {
 				return versions.get(0).getId();
 			}
-			throw new CliException("You must specify a version to query!");
+			throw new CliException("You must specify a Changeset ID to query!");
 		});
 		Version version = state.getChangelog().getRoot();
 		while (version != null && !version.getChangeSet().equals(changeSetId)) {
 			version = version.getChild();
 		}
 		if (version == null) {
-			throw new CliException("You must specify a (valid) version to query");
+			throw new CliException("You must specify a (valid) Changeset ID to query");
 		}
 
 		return version.getChangeSet().getVersion();

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
@@ -188,7 +188,7 @@ public class Query extends Command {
 
 	private Version getVersionId(List<String> arguments, Config config) {
 		State state = loadState(config.getBackend());
-		String versionId = getArgument(arguments, "version", String.class, () -> {
+		String changeSetId = getArgument(arguments, "version", String.class, () -> {
 			List<Version> versions = Lists.newArrayList(state.getRefLog().getVersions());
 			if (versions.isEmpty()) {
 				versions.add(state.getChangelog().getRoot());
@@ -199,10 +199,15 @@ public class Query extends Command {
 			}
 			throw new CliException("You must specify a version to query!");
 		});
+		Version version = state.getChangelog().getRoot();
+		while (version != null && !version.getChangeSet().equals(changeSetId)) {
+			version = version.getChild();
+		}
+		if (version == null) {
+			throw new CliException("You must specify a (valid) version to query");
+		}
 
-		return Optional.ofNullable(versionId)
-				.map(state.getChangelog()::getVersion)
-				.orElseThrow(() -> new CliException("You must specify a (valid) version to query"));
+		return version.getChangeSet().getVersion();
 	}
 
 }

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
@@ -17,13 +17,20 @@ public class ChangelogLoader {
 		List<XmlChangeset> changesets = xml.getChangesets();
 
 		Version pointer = changelog.getRoot().getChild();
-		for (XmlChangeset changeset : changesets) {
+		for (int i = 0; i < changesets.size(); i++) {
+			XmlChangeset changeset = changesets.get(i);
 			String changesetId = changeset.getId();
 			if (pointer != null) {
 				for (int index = 1; index <= changeset.getOperations().size(); index++) {
 					XmlOperation<?> xmlOperation = changeset.getOperations().get(index - 1);
 					Operation operation = xmlOperation.toOperation();
 					Operation currentOperation = pointer.getOperation();
+
+					if (pointer.getChangeSet().getAuthor().equals("QuantumDB")) {
+						pointer = pointer.getChild();
+						i--;
+						break;
+					}
 
 					if (!operation.equals(currentOperation)) {
 						throw new IllegalStateException("Operation at index: " + index + " in changeset: "

--- a/quantumdb-core/src/main/java/io/quantumdb/core/backends/Backend.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/backends/Backend.java
@@ -3,6 +3,7 @@ package io.quantumdb.core.backends;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import io.quantumdb.core.migration.Migrator.Stage;
 import io.quantumdb.core.versioning.State;
 import io.quantumdb.core.versioning.Version;
 
@@ -21,10 +22,11 @@ public interface Backend {
 	 * Persists the current state of the database schema and its evolution to the database.
 	 *
 	 * @param state The current state of the database schema.
+	 * @param stage The stage that QuantumDB might want to save. Can be null.
 	 *
 	 * @throws SQLException In case the database could not be reached, or queried correctly.
 	 */
-	void persistState(State state) throws SQLException;
+	void persistState(State state, Stage stage) throws SQLException;
 
 	/**
 	 * Creates a connection to the database.

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
@@ -61,10 +61,8 @@ public class Migrator {
 		this.backend = backend;
 	}
 
-	public void migrate(String sourceVersionId, String targetVersionId) throws MigrationException {
+	public void migrate(State state, String sourceVersionId, String targetVersionId) throws MigrationException {
 		log.info("Forking from version: {} to version: {}", sourceVersionId, targetVersionId);
-
-		State state = loadState();
 
 		Changelog changelog = state.getChangelog();
 		Version from = changelog.getVersion(sourceVersionId);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
@@ -61,8 +61,10 @@ public class Migrator {
 		this.backend = backend;
 	}
 
-	public void migrate(State state, String sourceVersionId, String targetVersionId) throws MigrationException {
+	public void migrate(String sourceVersionId, String targetVersionId) throws MigrationException {
 		log.info("Forking from version: {} to version: {}", sourceVersionId, targetVersionId);
+
+		State state = loadState();
 
 		Changelog changelog = state.getChangelog();
 		Version from = changelog.getVersion(sourceVersionId);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/Migrator.java
@@ -61,10 +61,9 @@ public class Migrator {
 		this.backend = backend;
 	}
 
-	public void migrate(String sourceVersionId, String targetVersionId) throws MigrationException {
+	public void migrate(State state, String sourceVersionId, String targetVersionId) throws MigrationException {
 		log.info("Forking from version: {} to version: {}", sourceVersionId, targetVersionId);
 
-		State state = loadState();
 		Changelog changelog = state.getChangelog();
 		Version from = changelog.getVersion(sourceVersionId);
 		Version to = changelog.getVersion(targetVersionId);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddColumnMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddColumnMigrator.java
@@ -16,7 +16,7 @@ class AddColumnMigrator implements SchemaOperationMigrator<AddColumn> {
 	@Override
 	public void migrate(Catalog catalog, RefLog refLog, Version version, AddColumn operation) {
 		String tableName = operation.getTableName();
-		TransitiveTableMirrorer.mirror(catalog, refLog, version, tableName);
+		TransitiveTableMirrorer.mirror(catalog, refLog, version, false, tableName);
 
 		TableRef tableRef = refLog.getTableRef(version, tableName);
 		Table table = catalog.getTable(tableRef.getRefId());

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddForeignKeyMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AddForeignKeyMigrator.java
@@ -15,7 +15,7 @@ class AddForeignKeyMigrator implements SchemaOperationMigrator<AddForeignKey> {
 	@Override
 	public void migrate(Catalog catalog, RefLog refLog, Version version, AddForeignKey operation) {
 		String tableName = operation.getReferringTableName();
-		TransitiveTableMirrorer.mirror(catalog, refLog, version, tableName);
+		TransitiveTableMirrorer.mirror(catalog, refLog, version, false, tableName);
 
 		TableRef tableRef = refLog.getTableRef(version, tableName);
 		Table table = catalog.getTable(tableRef.getRefId());

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AlterColumnMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AlterColumnMigrator.java
@@ -23,7 +23,7 @@ class AlterColumnMigrator implements SchemaOperationMigrator<AlterColumn> {
 	@Override
 	public void migrate(Catalog catalog, RefLog refLog, Version version, AlterColumn operation) {
 		String tableName = operation.getTableName();
-		TransitiveTableMirrorer.mirror(catalog, refLog, version, tableName);
+		TransitiveTableMirrorer.mirror(catalog, refLog, version, false, tableName);
 
 		TableRef tableRef = refLog.getTableRef(version, tableName);
 		Table table = catalog.getTable(tableRef.getRefId());

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CleanupTablesMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CleanupTablesMigrator.java
@@ -1,0 +1,25 @@
+package io.quantumdb.core.migration.operations;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.quantumdb.core.schema.definitions.Catalog;
+import io.quantumdb.core.schema.operations.CleanupTables;
+import io.quantumdb.core.versioning.RefLog;
+import io.quantumdb.core.versioning.RefLog.TableRef;
+import io.quantumdb.core.versioning.Version;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+public class CleanupTablesMigrator implements SchemaOperationMigrator<CleanupTables> {
+
+	@Override
+	public void migrate(Catalog catalog, RefLog refLog, Version version, CleanupTables operation) {
+		checkArgument(refLog.getVersions().size() == 1, "You may only use the cleanup command if there is 1 active version.");
+		TransitiveTableMirrorer.mirror(catalog, refLog, version, true, refLog.getTableRefs(version.getParent()).stream()
+				.filter(tableRef -> !tableRef.getRefId().equals(tableRef.getName()))
+				.map(TableRef::getName).toArray(String[]::new));
+
+	}
+
+}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CleanupTablesMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CleanupTablesMigrator.java
@@ -1,7 +1,5 @@
 package io.quantumdb.core.migration.operations;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.operations.CleanupTables;
 import io.quantumdb.core.versioning.RefLog;
@@ -15,11 +13,9 @@ public class CleanupTablesMigrator implements SchemaOperationMigrator<CleanupTab
 
 	@Override
 	public void migrate(Catalog catalog, RefLog refLog, Version version, CleanupTables operation) {
-		checkArgument(refLog.getVersions().size() == 1, "You may only use the cleanup command if there is 1 active version.");
 		TransitiveTableMirrorer.mirror(catalog, refLog, version, true, refLog.getTableRefs(version.getParent()).stream()
 				.filter(tableRef -> !tableRef.getRefId().equals(tableRef.getName()))
 				.map(TableRef::getName).toArray(String[]::new));
-
 	}
 
 }

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CreateIndexMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/CreateIndexMigrator.java
@@ -16,7 +16,7 @@ class CreateIndexMigrator implements SchemaOperationMigrator<CreateIndex> {
 	@Override
 	public void migrate(Catalog catalog, RefLog refLog, Version version, CreateIndex operation) {
 		String tableName = operation.getTableName();
-		TransitiveTableMirrorer.mirror(catalog, refLog, version, tableName);
+		TransitiveTableMirrorer.mirror(catalog, refLog, version, false, tableName);
 
 		TableRef tableRef = refLog.getTableRef(version, tableName);
 		String refId = tableRef.getRefId();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropColumnMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropColumnMigrator.java
@@ -19,7 +19,7 @@ class DropColumnMigrator implements SchemaOperationMigrator<DropColumn> {
 	@Override
 	public void migrate(Catalog catalog, RefLog refLog, Version version, DropColumn operation) {
 		String tableName = operation.getTableName();
-		TransitiveTableMirrorer.mirror(catalog, refLog, version, tableName);
+		TransitiveTableMirrorer.mirror(catalog, refLog, version, false, tableName);
 
 		TableRef tableRef = refLog.getTableRef(version, tableName);
 		String refId = tableRef.getRefId();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropForeignKeyMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropForeignKeyMigrator.java
@@ -16,7 +16,7 @@ class DropForeignKeyMigrator implements SchemaOperationMigrator<DropForeignKey> 
 	@Override
 	public void migrate(Catalog catalog, RefLog refLog, Version version, DropForeignKey operation) {
 		String tableName = operation.getTableName();
-		TransitiveTableMirrorer.mirror(catalog, refLog, version, tableName);
+		TransitiveTableMirrorer.mirror(catalog, refLog, version, false, tableName);
 
 		TableRef tableRef = refLog.getTableRef(version, tableName);
 		Table table = catalog.getTable(tableRef.getRefId());

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropIndexMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropIndexMigrator.java
@@ -15,7 +15,7 @@ class DropIndexMigrator implements SchemaOperationMigrator<DropIndex> {
 	@Override
 	public void migrate(Catalog catalog, RefLog refLog, Version version, DropIndex operation) {
 		String tableName = operation.getTableName();
-		TransitiveTableMirrorer.mirror(catalog, refLog, version, tableName);
+		TransitiveTableMirrorer.mirror(catalog, refLog, version, false, tableName);
 
 		TableRef tableRef = refLog.getTableRef(version, tableName);
 		String refId = tableRef.getRefId();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/SchemaOperationsMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/SchemaOperationsMigrator.java
@@ -7,6 +7,7 @@ import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.operations.AddColumn;
 import io.quantumdb.core.schema.operations.AddForeignKey;
 import io.quantumdb.core.schema.operations.AlterColumn;
+import io.quantumdb.core.schema.operations.CleanupTables;
 import io.quantumdb.core.schema.operations.CopyTable;
 import io.quantumdb.core.schema.operations.CreateIndex;
 import io.quantumdb.core.schema.operations.CreateTable;
@@ -46,6 +47,7 @@ public class SchemaOperationsMigrator {
 				.put(DropColumn.class, new DropColumnMigrator())
 				.put(DropForeignKey.class, new DropForeignKeyMigrator())
 				.put(RenameTable.class, new RenameTableMigrator())
+				.put(CleanupTables.class, new CleanupTablesMigrator())
 				.put(CreateView.class, new CreateViewMigrator())
 				.put(DropView.class, new DropViewMigrator())
 				.build();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class TransitiveTableMirrorer {
 
-	static Set<String> mirror(Catalog catalog, RefLog refLog, Version version, Boolean cleanup, String... tableNames) {
+	static Set<String> mirror(Catalog catalog, RefLog refLog, Version version, boolean cleanup, String... tableNames) {
 		refLog.fork(version);
 		Version parentVersion = version.getParent();
 		Set<String> mirrored = Sets.newHashSet();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/TransitiveTableMirrorer.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class TransitiveTableMirrorer {
 
-	static Set<String> mirror(Catalog catalog, RefLog refLog, Version version, String... tableNames) {
+	static Set<String> mirror(Catalog catalog, RefLog refLog, Version version, Boolean cleanup, String... tableNames) {
 		refLog.fork(version);
 		Version parentVersion = version.getParent();
 		Set<String> mirrored = Sets.newHashSet();
@@ -35,7 +35,13 @@ class TransitiveTableMirrorer {
 				continue;
 			}
 
-			String newRefId = RandomHasher.generateRefId(refLog);
+			String newRefId;
+			if (cleanup && !tableRef.getRefId().equals(tableRef.getName())) {
+				newRefId = tableRef.getName();
+			}
+			else {
+				newRefId = RandomHasher.generateRefId(refLog);
+			}
 			Table table = catalog.getTable(tableRef.getRefId());
 			tableRef.ghost(newRefId, version);
 			catalog.addTable(table.copy().rename(newRefId));

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/CleanupTables.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/CleanupTables.java
@@ -1,0 +1,13 @@
+package io.quantumdb.core.schema.operations;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class CleanupTables implements SchemaOperation {
+
+	CleanupTables() {
+	}
+
+}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/SchemaOperations.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/SchemaOperations.java
@@ -20,6 +20,10 @@ public class SchemaOperations {
 		return new RenameTable(tableName, newTableName);
 	}
 
+	public static CleanupTables cleanupTables() {
+		return new CleanupTables();
+	}
+
 	public static CopyTable copyTable(String sourceTableName, String targetTableName) {
 		return new CopyTable(sourceTableName, targetTableName);
 	}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
@@ -100,15 +100,9 @@ public class Changelog {
 	 */
 	public Changelog addChangeSet(Version appendTo, ChangeSet changeSet, Collection<Operation> operations) {
 		lastAdded = appendTo;
-		int size = operations.size();
+
 		for (Operation operation : operations) {
-			size--;
-			if (size == 0) {
-				lastAdded = new Version(changeSet.getId(), lastAdded, changeSet, operation);
-			}
-			else {
 				lastAdded = new Version(idGenerator.generateId(), lastAdded, changeSet, operation);
-			}
 		}
 
 		changeSet.setVersion(lastAdded);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
@@ -100,9 +100,15 @@ public class Changelog {
 	 */
 	public Changelog addChangeSet(Version appendTo, ChangeSet changeSet, Collection<Operation> operations) {
 		lastAdded = appendTo;
-
+		int size = operations.size();
 		for (Operation operation : operations) {
-			lastAdded = new Version(idGenerator.generateId(), lastAdded, changeSet, operation);
+			size--;
+			if (size == 0) {
+				lastAdded = new Version(changeSet.getId(), lastAdded, changeSet, operation);
+			}
+			else {
+				lastAdded = new Version(idGenerator.generateId(), lastAdded, changeSet, operation);
+			}
 		}
 
 		changeSet.setVersion(lastAdded);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Changelog.java
@@ -102,7 +102,7 @@ public class Changelog {
 		lastAdded = appendTo;
 
 		for (Operation operation : operations) {
-				lastAdded = new Version(idGenerator.generateId(), lastAdded, changeSet, operation);
+			lastAdded = new Version(idGenerator.generateId(), lastAdded, changeSet, operation);
 		}
 
 		changeSet.setVersion(lastAdded);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Operations.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/versioning/Operations.java
@@ -7,6 +7,7 @@ import com.google.common.collect.HashBiMap;
 import io.quantumdb.core.schema.operations.AddColumn;
 import io.quantumdb.core.schema.operations.AddForeignKey;
 import io.quantumdb.core.schema.operations.AlterColumn;
+import io.quantumdb.core.schema.operations.CleanupTables;
 import io.quantumdb.core.schema.operations.CopyTable;
 import io.quantumdb.core.schema.operations.CreateIndex;
 import io.quantumdb.core.schema.operations.CreateTable;
@@ -47,6 +48,7 @@ class Operations {
 		mapping.put("merge-table", MergeTable.class);
 		mapping.put("partition-table", PartitionTable.class);
 		mapping.put("rename-table", RenameTable.class);
+		mapping.put("cleanup-tables", CleanupTables.class);
 	}
 
 	public Optional<Class<? extends Operation>> getOperationType(String operationType) {

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlBackend.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlBackend.java
@@ -8,6 +8,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import io.quantumdb.core.backends.Config;
+import io.quantumdb.core.migration.Migrator.Stage;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.versioning.Backend;
 import io.quantumdb.core.versioning.QuantumTables;
@@ -38,7 +39,7 @@ public class PostgresqlBackend implements io.quantumdb.core.backends.Backend {
 	}
 
 	@Override
-	public void persistState(State state) throws SQLException {
+	public void persistState(State state, Stage stage) throws SQLException {
 		if (config.isDryRun()) {
 			return;
 		}
@@ -47,7 +48,7 @@ public class PostgresqlBackend implements io.quantumdb.core.backends.Backend {
 
 		try (Connection connection = connect()) {
 			connection.setAutoCommit(false);
-			backend.persist(connection, state);
+			backend.persist(connection, state, stage);
 			connection.commit();
 		}
 	}

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/PostgresqlMigrator.java
@@ -104,7 +104,7 @@ class PostgresqlMigrator implements DatabaseMigrator {
 				}
 			}
 			connection.commit();
-			backend.persistState(state);
+			backend.persistState(state, stage);
 		}
 		catch (SQLException e) {
 			throw new MigrationException("Exception happened while performing data changes.", e);
@@ -178,7 +178,7 @@ class PostgresqlMigrator implements DatabaseMigrator {
 			}
 			dropTables(connection, refLog, catalog, tablesToDrop);
 			refLog.setVersionState(version, false);
-			backend.persistState(state);
+			backend.persistState(state, null);
 			connection.commit();
 		}
 		catch (SQLException e) {
@@ -328,7 +328,7 @@ class PostgresqlMigrator implements DatabaseMigrator {
 
 		private void persistState() throws MigrationException {
 			try {
-				backend.persistState(state);
+				backend.persistState(state, null);
 			}
 			catch (SQLException e) {
 				throw new MigrationException(e);

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
@@ -62,7 +62,7 @@ public class TableCreator {
 				queryBuilder.append(", ");
 			}
 
-			queryBuilder.append("\"" + column.getName() + "\" " + column.getType());
+			queryBuilder.append(quoted(column.getName()) + " " + column.getType());
 			if (column.isNotNull()) {
 				queryBuilder.append("NOT NULL");
 			}

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
@@ -38,6 +38,7 @@ import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.ColumnType;
 import io.quantumdb.core.schema.definitions.PostgresTypes;
 import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.utils.RandomHasher;
 import io.quantumdb.core.versioning.RefLog.ColumnRef;
 import io.quantumdb.core.versioning.RefLog.SyncRef;
 import io.quantumdb.core.versioning.RefLog.TableRef;
@@ -877,7 +878,7 @@ public class Backend {
 		}
 
 		if (root == null) {
-			root = new RawChangelogEntry("initial", null, null, null);
+			root = new RawChangelogEntry(RandomHasher.generateHash(), null, null, null);
 		}
 
 		List<RawChangelogEntry> pointer = Lists.newArrayList(root);

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/versioning/Backend.java
@@ -33,6 +33,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
+import io.quantumdb.core.migration.Migrator.Stage;
 import io.quantumdb.core.schema.definitions.Catalog;
 import io.quantumdb.core.schema.definitions.ColumnType;
 import io.quantumdb.core.schema.definitions.PostgresTypes;
@@ -175,11 +176,14 @@ public class Backend {
 		return new State(catalog, refLog, changelog);
 	}
 
-	public void persist(Connection connection, State state) throws SQLException {
+	public void persist(Connection connection, State state, Stage stage) throws SQLException {
 		RefLog refLog = state.getRefLog();
 		Version lastActive = state.getChangelog().getLastAdded();
 		while (lastActive != null && !refLog.getVersions().contains(lastActive)) {
 			lastActive = lastActive.getParent();
+		}
+		if (stage != null) {
+			lastActive = stage.getLast();
 		}
 		persistChangelog(connection, state.getChangelog(), lastActive);
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
@@ -65,7 +65,7 @@ public class MultiStateTest extends PostgresqlDatabase {
 						addColumn("test", "admin", bool(), "'false'", NOT_NULL))
 				.getLastAdded();
 
-		backend.persistState(state);
+		backend.persistState(state, null);
 	}
 
 	@Test

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 public class MultiStateTest extends PostgresqlDatabase {
 
 	private Backend backend;
+	private State state;
 	private Version step0;
 	private Version step1;
 	private Version step4;
@@ -44,7 +45,7 @@ public class MultiStateTest extends PostgresqlDatabase {
 
 		backend = config.getBackend();
 
-		State state = backend.loadState();
+		state = backend.loadState();
 		Changelog changelog = state.getChangelog();
 
 		step0 = changelog.getRoot();
@@ -65,14 +66,16 @@ public class MultiStateTest extends PostgresqlDatabase {
 				addColumn("test", "admin", bool(), "'false'", NOT_NULL))
 				.getLastAdded();
 
+		System.out.println(changelog);
+
 		backend.persistState(state, null);
 	}
 
 	@Test
 	public void testMigratingOverDataChange() throws MigrationException, SQLException {
 		Migrator migrator = new Migrator(backend);
-		migrator.migrate(step0.getId(), step1.getId());
-		migrator.migrate(step1.getId(), step4.getId());
+		migrator.migrate(state, step0.getId(), step1.getId());
+		migrator.migrate(state, step1.getId(), step4.getId());
 		migrator.drop(step1.getId());
 	}
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
@@ -50,19 +50,19 @@ public class MultiStateTest extends PostgresqlDatabase {
 		step0 = changelog.getRoot();
 
 		step1 = changelog.addChangeSet("step1", "Michael de Jong", "Create test table.",
-						createTable("test").with("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT))
+				createTable("test").with("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT))
 				.getLastAdded();
 
 		changelog.addChangeSet("step2", "Michael de Jong", "Add name column to test table.",
-						addColumn("test", "name", varchar(255), "''", NOT_NULL))
+				addColumn("test", "name", varchar(255), "''", NOT_NULL))
 				.getLastAdded();
 
 		changelog.addChangeSet("step3", "Michael de Jong", "Insert default user account into test table.",
-						execute("INSERT INTO test (name) VALUES ('Hello');"))
+				execute("INSERT INTO test (name) VALUES ('Hello');"))
 				.getLastAdded();
 
 		step4 = changelog.addChangeSet("step4", "Michael de Jong", "Created admin flag for test table.",
-						addColumn("test", "admin", bool(), "'false'", NOT_NULL))
+				addColumn("test", "admin", bool(), "'false'", NOT_NULL))
 				.getLastAdded();
 
 		backend.persistState(state, null);
@@ -71,9 +71,8 @@ public class MultiStateTest extends PostgresqlDatabase {
 	@Test
 	public void testMigratingOverDataChange() throws MigrationException, SQLException {
 		Migrator migrator = new Migrator(backend);
-		State state = backend.loadState();
-		migrator.migrate(state, step0.getId(), step1.getId());
-		migrator.migrate(state, step1.getId(), step4.getId());
+		migrator.migrate(step0.getId(), step1.getId());
+		migrator.migrate(step1.getId(), step4.getId());
 		migrator.drop(step1.getId());
 	}
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
@@ -50,29 +50,30 @@ public class MultiStateTest extends PostgresqlDatabase {
 		step0 = changelog.getRoot();
 
 		step1 = changelog.addChangeSet("step1", "Michael de Jong", "Create test table.",
-				createTable("test").with("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT))
+						createTable("test").with("id", bigint(), PRIMARY_KEY, AUTO_INCREMENT))
 				.getLastAdded();
 
 		changelog.addChangeSet("step2", "Michael de Jong", "Add name column to test table.",
-				addColumn("test", "name", varchar(255), "''", NOT_NULL))
+						addColumn("test", "name", varchar(255), "''", NOT_NULL))
 				.getLastAdded();
 
 		changelog.addChangeSet("step3", "Michael de Jong", "Insert default user account into test table.",
-				execute("INSERT INTO test (name) VALUES ('Hello');"))
+						execute("INSERT INTO test (name) VALUES ('Hello');"))
 				.getLastAdded();
 
 		step4 = changelog.addChangeSet("step4", "Michael de Jong", "Created admin flag for test table.",
-				addColumn("test", "admin", bool(), "'false'", NOT_NULL))
+						addColumn("test", "admin", bool(), "'false'", NOT_NULL))
 				.getLastAdded();
 
 		backend.persistState(state);
 	}
 
 	@Test
-	public void testMigratingOverDataChange() throws MigrationException {
+	public void testMigratingOverDataChange() throws MigrationException, SQLException {
 		Migrator migrator = new Migrator(backend);
-		migrator.migrate(step0.getId(), step1.getId());
-		migrator.migrate(step1.getId(), step4.getId());
+		State state = backend.loadState();
+		migrator.migrate(state, step0.getId(), step1.getId());
+		migrator.migrate(state, step1.getId(), step4.getId());
 		migrator.drop(step1.getId());
 	}
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/CopyTypesTables.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/CopyTypesTables.java
@@ -85,7 +85,7 @@ public class CopyTypesTables {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/CopyTypesTables.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/CopyTypesTables.java
@@ -83,7 +83,7 @@ public class CopyTypesTables {
 				SchemaOperations.copyTable("oid", "oid_backup"));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/CopyTypesTables.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/CopyTypesTables.java
@@ -85,7 +85,7 @@ public class CopyTypesTables {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/CopyTypesTables.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/CopyTypesTables.java
@@ -85,7 +85,7 @@ public class CopyTypesTables {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}
@@ -102,7 +102,7 @@ public class CopyTypesTables {
 				.addColumn(new Column("smallint", smallint(), NOT_NULL))
 				.addColumn(new Column("smallnumeric_integer", numeric(5, 0), NOT_NULL))
 				.addColumn(new Column("smallnumeric_decimal", numeric(5, 2), NOT_NULL))
-				.addColumn(new Column("smallnumeric", numeric(5,0), NOT_NULL));
+				.addColumn(new Column("smallnumeric", numeric(5, 0), NOT_NULL));
 
 		Table numeric = new Table(refLog.getTableRef(origin, "numeric").getRefId())
 				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
@@ -111,7 +111,7 @@ public class CopyTypesTables {
 				.addColumn(new Column("double", doubles(), NOT_NULL))
 				.addColumn(new Column("numeric_integer", numeric(10, 0), NOT_NULL))
 				.addColumn(new Column("numeric_decimal", numeric(10, 5), NOT_NULL))
-				.addColumn(new Column("numeric", numeric(10,0), NOT_NULL));
+				.addColumn(new Column("numeric", numeric(10, 0), NOT_NULL));
 
 		Table numeric_big = new Table(refLog.getTableRef(origin, "numeric_big").getRefId())
 				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
@@ -161,7 +161,7 @@ public class CopyTypesTables {
 				.addColumn(new Column("smallint", smallint(), NOT_NULL))
 				.addColumn(new Column("smallnumeric_integer", numeric(5, 0), NOT_NULL))
 				.addColumn(new Column("smallnumeric_decimal", numeric(5, 2), NOT_NULL))
-				.addColumn(new Column("smallnumeric", numeric(5,0), NOT_NULL));
+				.addColumn(new Column("smallnumeric", numeric(5, 0), NOT_NULL));
 
 		Table new_numeric = new Table(refLog.getTableRef(target, "numeric_backup").getRefId())
 				.addColumn(new Column("id", integer(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
@@ -170,7 +170,7 @@ public class CopyTypesTables {
 				.addColumn(new Column("double", doubles(), NOT_NULL))
 				.addColumn(new Column("numeric_integer", numeric(10, 0), NOT_NULL))
 				.addColumn(new Column("numeric_decimal", numeric(10, 5), NOT_NULL))
-				.addColumn(new Column("numeric", numeric(10,0), NOT_NULL));
+				.addColumn(new Column("numeric", numeric(10, 0), NOT_NULL));
 
 		Table new_numeric_big = new Table(refLog.getTableRef(target, "numeric_big_backup").getRefId())
 				.addColumn(new Column("id", bigint(), PRIMARY_KEY, NOT_NULL, AUTO_INCREMENT))
@@ -365,14 +365,14 @@ public class CopyTypesTables {
 		catch (SQLException throwables) {
 			throwables.printStackTrace();
 		}
-		
+
 	}
 
 	public void insertTestDataInCopiedTables() throws SQLException {
 		RefLog refLog = state.getRefLog();
-		
+
 		Connection connection = setup.getConnection();
-		
+
 		connection.setAutoCommit(false);
 		connection.createStatement().execute("SET CONSTRAINTS ALL DEFERRED");
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/PostgresqlTypesScenario.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/types/PostgresqlTypesScenario.java
@@ -177,7 +177,7 @@ public class PostgresqlTypesScenario extends PostgresqlDatabase {
 			refLog.addTable(tableName, refId, changelog.getRoot(), columns);
 		});
 
-		backend.persistState(state);
+		backend.persistState(state, null);
 		migrator = new Migrator(backend);
 	}
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
@@ -53,7 +53,7 @@ public class AddColumnToCustomersTable {
 				SchemaOperations.addColumn("customers", "date_of_birth", date()));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
@@ -55,7 +55,7 @@ public class AddColumnToCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
@@ -55,7 +55,7 @@ public class AddColumnToCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToCustomersTable.java
@@ -55,7 +55,7 @@ public class AddColumnToCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
@@ -51,7 +51,7 @@ public class AddColumnToFilmsTable {
 				SchemaOperations.addColumn("films", "release_date", date()));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
@@ -53,7 +53,7 @@ public class AddColumnToFilmsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
@@ -53,7 +53,7 @@ public class AddColumnToFilmsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToFilmsTable.java
@@ -53,7 +53,7 @@ public class AddColumnToFilmsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
@@ -52,7 +52,7 @@ public class AddColumnToPaymentsTable {
 				SchemaOperations.addColumn("payments", "verified", bool(), "'false'", NOT_NULL));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
@@ -54,7 +54,7 @@ public class AddColumnToPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
@@ -54,7 +54,7 @@ public class AddColumnToPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddColumnToPaymentsTable.java
@@ -54,7 +54,7 @@ public class AddColumnToPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
@@ -56,7 +56,7 @@ public class AddForeignKeyToPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
@@ -56,7 +56,7 @@ public class AddForeignKeyToPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
@@ -56,7 +56,7 @@ public class AddForeignKeyToPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}
@@ -144,7 +144,7 @@ public class AddForeignKeyToPaymentsTable {
 		newPayments.addForeignKey("store_id").referencing(stores, "id");
 
 		List<Table> tables = Lists.newArrayList(stores, staff, customers, films, inventory, paychecks, payments, rentals,
-						newPayments);
+				newPayments);
 
 		Catalog expected = new Catalog(setup.getCatalog().getName());
 		tables.forEach(expected::addTable);

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/AddForeignKeyToPaymentsTable.java
@@ -54,7 +54,7 @@ public class AddForeignKeyToPaymentsTable {
 				SchemaOperations.addForeignKey("payments", "store_id").referencing("stores", "id"));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
@@ -55,7 +55,7 @@ public class CopyCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
@@ -53,7 +53,7 @@ public class CopyCustomersTable {
 				SchemaOperations.copyTable("customers", "customers_backup"));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
@@ -55,7 +55,7 @@ public class CopyCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CopyCustomersTable.java
@@ -55,7 +55,7 @@ public class CopyCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
@@ -58,7 +58,7 @@ public class CreateCreditCardsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
@@ -56,7 +56,7 @@ public class CreateCreditCardsTable {
 						.with("expiration_date", date(), NOT_NULL));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
@@ -58,7 +58,7 @@ public class CreateCreditCardsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/CreateCreditCardsTable.java
@@ -58,7 +58,7 @@ public class CreateCreditCardsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
@@ -53,7 +53,7 @@ public class DropColumnFromCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
@@ -53,7 +53,7 @@ public class DropColumnFromCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
@@ -53,7 +53,7 @@ public class DropColumnFromCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropColumnFromCustomersTable.java
@@ -51,7 +51,7 @@ public class DropColumnFromCustomersTable {
 				SchemaOperations.dropColumn("customers", "referred_by"));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
@@ -55,7 +55,7 @@ public class DropForeignKeyFromCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
@@ -53,7 +53,7 @@ public class DropForeignKeyFromCustomersTable {
 				SchemaOperations.dropForeignKey("customers", "customer_registered_at_store"));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
@@ -55,7 +55,7 @@ public class DropForeignKeyFromCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropForeignKeyFromCustomersTable.java
@@ -55,7 +55,7 @@ public class DropForeignKeyFromCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
@@ -50,7 +50,7 @@ public class DropPaymentsTable {
 				SchemaOperations.dropTable("payments"));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
@@ -52,7 +52,7 @@ public class DropPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
@@ -52,7 +52,7 @@ public class DropPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/DropPaymentsTable.java
@@ -52,7 +52,7 @@ public class DropPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
@@ -51,7 +51,7 @@ public class MakeStoreFieldInStaffTableNullable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
@@ -49,7 +49,7 @@ public class MakeStoreFieldInStaffTableNullable {
 						.dropHint(NOT_NULL));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
@@ -51,7 +51,7 @@ public class MakeStoreFieldInStaffTableNullable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/MakeStoreFieldInStaffTableNullable.java
@@ -51,7 +51,7 @@ public class MakeStoreFieldInStaffTableNullable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
@@ -55,7 +55,7 @@ public class ModifyTypeInPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
@@ -55,7 +55,7 @@ public class ModifyTypeInPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
@@ -55,7 +55,7 @@ public class ModifyTypeInPaymentsTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/ModifyTypeInPaymentsTable.java
@@ -53,7 +53,7 @@ public class ModifyTypeInPaymentsTable {
 						.modifyDataType(doubles()));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/PostgresqlBaseScenario.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/PostgresqlBaseScenario.java
@@ -170,7 +170,7 @@ public class PostgresqlBaseScenario extends PostgresqlDatabase {
 			refLog.addTable(tableName, refId, changelog.getRoot(), columns);
 		});
 
-		backend.persistState(state);
+		backend.persistState(state, null);
 		migrator = new Migrator(backend);
 	}
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
@@ -56,7 +56,7 @@ public class RenameCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
@@ -54,7 +54,7 @@ public class RenameCustomersTable {
 				SchemaOperations.renameTable("customers", "clients"));
 
 		target = setup.getChangelog().getLastAdded();
-		setup.getBackend().persistState(setup.getState());
+		setup.getBackend().persistState(setup.getState(), null);
 
 		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
@@ -56,7 +56,7 @@ public class RenameCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState());
 
-		setup.getMigrator().migrate(origin.getId(), target.getId());
+		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}
@@ -154,7 +154,7 @@ public class RenameCustomersTable {
 				.put(RENTALS_ID, "rentals")
 				.build();
 
-		Map<String, String>expectedTargetRefIds = ImmutableMap.<String, String>builder()
+		Map<String, String> expectedTargetRefIds = ImmutableMap.<String, String>builder()
 				.put(STORES_ID, "stores")
 				.put(STAFF_ID, "staff")
 				.put(CUSTOMERS_ID, "clients")

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/videostores/RenameCustomersTable.java
@@ -56,7 +56,7 @@ public class RenameCustomersTable {
 		target = setup.getChangelog().getLastAdded();
 		setup.getBackend().persistState(setup.getState(), null);
 
-		setup.getMigrator().migrate(setup.getState(), origin.getId(), target.getId());
+		setup.getMigrator().migrate(origin.getId(), target.getId());
 
 		state = setup.getBackend().loadState();
 	}

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/SyncFunctionTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/SyncFunctionTest.java
@@ -58,8 +58,8 @@ public class SyncFunctionTest {
 		String createFunctionStatement = function.createFunctionStatement().toString();
 		String createTriggerStatement = function.createTriggerStatement().toString();
 
-		assertEquals(createFunctionStatement, "CREATE OR REPLACE FUNCTION \"migrate_data\"() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); ELSIF TG_OP = 'UPDATE' THEN LOOP UPDATE \"table_b\" SET \"id\" = NEW.\"id\" WHERE \"id\" = OLD.\"id\"; IF found THEN EXIT; END IF; BEGIN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); EXIT; EXCEPTION WHEN unique_violation THEN END; END LOOP; ELSIF TG_OP = 'DELETE' THEN DELETE FROM \"table_b\" WHERE \"id\" = OLD.\"id\"; END IF; RETURN NEW; END; $$ LANGUAGE 'plpgsql';");
-		assertEquals(createTriggerStatement, "CREATE TRIGGER \"migration_trigger\" AFTER INSERT OR UPDATE OR DELETE ON \"table_a\" FOR EACH ROW WHEN (pg_trigger_depth() = 0) EXECUTE PROCEDURE \"migrate_data\"();");
+		assertEquals("CREATE OR REPLACE FUNCTION \"migrate_data\"() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); ELSIF TG_OP = 'UPDATE' THEN LOOP UPDATE \"table_b\" SET \"id\" = NEW.\"id\", \"name\" = NEW.\"name\" WHERE \"id\" = OLD.\"id\"; IF found THEN EXIT; END IF; BEGIN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); EXIT; EXCEPTION WHEN unique_violation THEN END; END LOOP; ELSIF TG_OP = 'DELETE' THEN DELETE FROM \"table_b\" WHERE \"id\" = OLD.\"id\"; END IF; RETURN NEW; END; $$ LANGUAGE 'plpgsql';", createFunctionStatement);
+		assertEquals("CREATE TRIGGER \"migration_trigger\" AFTER INSERT OR UPDATE OR DELETE ON \"table_a\" FOR EACH ROW WHEN (pg_trigger_depth() = 0) EXECUTE PROCEDURE \"migrate_data\"();", createTriggerStatement);
 	}
 
 }

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/SyncFunctionTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/planner/SyncFunctionTest.java
@@ -58,8 +58,8 @@ public class SyncFunctionTest {
 		String createFunctionStatement = function.createFunctionStatement().toString();
 		String createTriggerStatement = function.createTriggerStatement().toString();
 
-		assertEquals("CREATE OR REPLACE FUNCTION \"migrate_data\"() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); ELSIF TG_OP = 'UPDATE' THEN LOOP UPDATE \"table_b\" SET \"id\" = NEW.\"id\", \"name\" = NEW.\"name\" WHERE \"id\" = OLD.\"id\"; IF found THEN EXIT; END IF; BEGIN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); EXIT; EXCEPTION WHEN unique_violation THEN END; END LOOP; ELSIF TG_OP = 'DELETE' THEN DELETE FROM \"table_b\" WHERE \"id\" = OLD.\"id\"; END IF; RETURN NEW; END; $$ LANGUAGE 'plpgsql';", createFunctionStatement);
-		assertEquals("CREATE TRIGGER \"migration_trigger\" AFTER INSERT OR UPDATE OR DELETE ON \"table_a\" FOR EACH ROW WHEN (pg_trigger_depth() = 0) EXECUTE PROCEDURE \"migrate_data\"();", createTriggerStatement);
+		assertEquals(createFunctionStatement, "CREATE OR REPLACE FUNCTION \"migrate_data\"() RETURNS TRIGGER AS $$ BEGIN IF TG_OP = 'INSERT' THEN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); ELSIF TG_OP = 'UPDATE' THEN LOOP UPDATE \"table_b\" SET \"id\" = NEW.\"id\" WHERE \"id\" = OLD.\"id\"; IF found THEN EXIT; END IF; BEGIN INSERT INTO \"table_b\" (\"name\", \"id\") VALUES (NEW.\"name\", NEW.\"id\"); EXIT; EXCEPTION WHEN unique_violation THEN END; END LOOP; ELSIF TG_OP = 'DELETE' THEN DELETE FROM \"table_b\" WHERE \"id\" = OLD.\"id\"; END IF; RETURN NEW; END; $$ LANGUAGE 'plpgsql';");
+		assertEquals(createTriggerStatement, "CREATE TRIGGER \"migration_trigger\" AFTER INSERT OR UPDATE OR DELETE ON \"table_a\" FOR EACH ROW WHEN (pg_trigger_depth() = 0) EXECUTE PROCEDURE \"migrate_data\"();");
 	}
 
 }

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/versioning/BackendTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/versioning/BackendTest.java
@@ -78,7 +78,7 @@ public class BackendTest {
 
 		Backend backend = new Backend();
 		State expectedState = new State(catalog, refLog, changelog);
-		backend.persist(database.createConnection(), expectedState);
+		backend.persist(database.createConnection(), expectedState, null);
 
 		State actualState = backend.load(database.getConnection(), catalog);
 		assertEquals(expectedState, actualState);


### PR DESCRIPTION
This is my pull request for the cleanup command.

A new migrator is included that mirrors all tables that do not have their original name. This will still create two active versions but the older one can be dropped, after that the quantumdb schema can be deleted.

Additionally in this pull request, the last versionid of a changeset is the changesetid. You do not have to run 'changelog' over and over again to get the versionid you can fork to. 

Closes #66 