### PR TITLE
Create indices for ghost tables concurrently, as we're already writing data to them.

### DIFF
--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableCreator.java
@@ -140,7 +140,7 @@ public class TableCreator {
 			if (index.isUnique()) {
 				queryBuilder.append("UNIQUE");
 			}
-			queryBuilder.append("INDEX " + quoted(index.getIndexName()));
+			queryBuilder.append("INDEX CONCURRENTLY " + quoted(index.getIndexName()));
 			queryBuilder.append("ON " + quoted(index.getParent().getName()));
 			queryBuilder.append("(" + index.getColumns().stream().map(QueryUtils::quoted).collect(Collectors.joining(", ")) + ");");
 


### PR DESCRIPTION
Reported through #81. When we create new ghost tables, we first start installing migration functions/triggers, and copy over the data from the source tables, before adding any (unique) indices to the new ghost table. We do this post-copy because this is a lot faster. This does mean the table is already in use, and any index creation should be done concurrently so we don't block any running queries (which write to the ghost table indirectly).

Close #81