### PR TITLE
Casting values to the right types in migrator functions

### DIFF
--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/MigratorFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/MigratorFunction.java
@@ -1,6 +1,6 @@
 package io.quantumdb.core.planner;
 
-import java.util.List;
+import java.util.Map;
 
 import lombok.Data;
 
@@ -12,7 +12,7 @@ public class MigratorFunction {
 	}
 
 	private final String name;
-	private final List<String> parameters;
+	private final Map<String, String> parameters;
 	private final String createStatement;
 	private final String dropStatement;
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/MigratorFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/MigratorFunction.java
@@ -1,6 +1,6 @@
 package io.quantumdb.core.planner;
 
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import lombok.Data;
 
@@ -12,7 +12,7 @@ public class MigratorFunction {
 	}
 
 	private final String name;
-	private final Map<String, String> parameters;
+	private final LinkedHashMap<String, String> parameters;
 	private final String createStatement;
 	private final String dropStatement;
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
@@ -148,21 +148,26 @@ public class SelectiveMigratorFunction {
 		createStatement.append("  RETURN CONCAT('(', " + primaryKeyColumnNames.stream().map(value -> "r." + quoted(value)).collect(Collectors.joining(",',', ")) + ", ')');");
 		createStatement.append("END; $$ LANGUAGE 'plpgsql';");
 
+		List<String> parameterTypes = primaryKeyColumns.stream()
+				.map(column -> column.getType().getType().toString())
+				.collect(Collectors.toList());
+
 		QueryBuilder dropStatement = new QueryBuilder();
 		switch (stage) {
 			case INITIAL:
 				dropStatement.append("DROP FUNCTION " + quoted(functionName) + "();");
 				break;
 			case CONSECUTIVE:
-				List<String> parameterTypes = primaryKeyColumns.stream()
-						.map(column -> column.getType().toString())
-						.collect(Collectors.toList());
-
 				dropStatement.append("DROP FUNCTION " + quoted(functionName) + "(" + Joiner.on(",").join(parameterTypes) + ");");
 				break;
 		}
 
-		return new MigratorFunction(functionName, primaryKeyColumnNames, createStatement.toString(), dropStatement.toString());
+		LinkedHashMap<String, String> zippedPrimaryKeys = Maps.newLinkedHashMap();
+		for (int i = 0; i < primaryKeyColumnNames.size(); i++) {
+			zippedPrimaryKeys.put(primaryKeyColumnNames.get(i), parameterTypes.get(i));
+		}
+
+		return new MigratorFunction(functionName, zippedPrimaryKeys, createStatement.toString(), dropStatement.toString());
 	}
 
 	private static MigratorFunction createInsertMigrator(NullRecords nullRecords, RefLog refLog, Table source,
@@ -272,6 +277,9 @@ public class SelectiveMigratorFunction {
 		createStatement.append("  RETURN CONCAT('(', " + primaryKeyColumnNames.stream().map(value -> "r." + quoted(value)).collect(Collectors.joining(",',', ")) + ", ')');");
 		createStatement.append("END; $$ LANGUAGE 'plpgsql';");
 
+		List<String> parameterTypes = primaryKeyColumns.stream()
+				.map(column -> column.getType().getType().toString())
+				.collect(Collectors.toList());
 
 		QueryBuilder dropStatement = new QueryBuilder();
 
@@ -280,15 +288,16 @@ public class SelectiveMigratorFunction {
 				dropStatement.append("DROP FUNCTION " + quoted(functionName) + "();");
 				break;
 			case CONSECUTIVE:
-				List<String> parameterTypes = primaryKeyColumns.stream()
-						.map(column -> column.getType().toString())
-						.collect(Collectors.toList());
-
 				dropStatement.append("DROP FUNCTION " + quoted(functionName) + "(" + Joiner.on(",").join(parameterTypes) + ");");
 				break;
 		}
 
-		return new MigratorFunction(functionName, primaryKeyColumnNames, createStatement.toString(), dropStatement.toString());
+		LinkedHashMap<String, String> zippedPrimaryKeys = Maps.newLinkedHashMap();
+		for (int i = 0; i < primaryKeyColumnNames.size(); i++) {
+			zippedPrimaryKeys.put(primaryKeyColumnNames.get(i), parameterTypes.get(i));
+		}
+
+		return new MigratorFunction(functionName, zippedPrimaryKeys, createStatement.toString(), dropStatement.toString());
 	}
 
 }


### PR DESCRIPTION
Additionally, when migrating during load the last migration can return no record (in my case (,,,) for 4 primary key columns). QuantumDB did not handle this, now it checks if there are no return values and breaks.

fixes #84 