### PR TITLE
Added unit tests to the cli package

### DIFF
--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
@@ -1,6 +1,7 @@
 package io.quantumdb.cli.xml;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,6 +16,26 @@ public class ChangelogLoader {
 	public Changelog load(Changelog changelog, String file) throws IOException {
 		XmlChangelog xml = new XmlMapper().loadChangelog(file);
 		List<XmlChangeset> changesets = xml.getChangesets();
+
+		HashSet<String> idSet = new HashSet<>();
+		Version temp = changelog.getRoot();
+		idSet.add(temp.getId());
+		while (temp.getChild() != null) {
+			temp = temp.getChild();
+			if (idSet.contains(temp.getId())) {
+				throw new IllegalStateException("Existing changelog in the database already has two id's with the name: " + temp.getId() + ", please change one id in the database.");
+			}
+			idSet.add(temp.getId());
+		}
+
+		for (XmlChangeset changeset : changesets) {
+			if (idSet.contains(changeset.getId())) {
+				throw new IllegalStateException("Changelog must contain only unique id's, id: " + changeset.getId() + " is already present.");
+			}
+			else {
+				idSet.add(changeset.getId());
+			}
+		}
 
 		Version pointer = changelog.getRoot().getChild();
 		for (XmlChangeset changeset : changesets) {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
@@ -17,7 +17,7 @@ public class ChangelogLoader {
 		XmlChangelog xml = new XmlMapper().loadChangelog(file);
 		List<XmlChangeset> changesets = xml.getChangesets();
 
-		HashSet<String> idSet = new HashSet<>();
+		Set<String> idSet = new HashSet<>();
 		Version temp = changelog.getRoot();
 		idSet.add(temp.getId());
 		while (temp.getChild() != null) {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddColumn.java
@@ -21,12 +21,19 @@ public class XmlAddColumn implements XmlOperation<AddColumn> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlAddColumn operation = new XmlAddColumn();
-		operation.setTableName(element.getAttributes().get("tableName"));
+		operation.setTableName(element.getAttributes().remove("tableName"));
 
 		for (XmlElement child : element.getChildren()) {
 			if (child.getTag().equals("column")) {
 				operation.setColumn(XmlColumn.convert(child));
 			}
+			else {
+				throw new IllegalArgumentException("Child element: " + child.getTag() + " is not valid!");
+			}
+		}
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
 		}
 
 		return operation;

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddForeignKey.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAddForeignKey.java
@@ -12,27 +12,31 @@ import lombok.Data;
 @Data
 public class XmlAddForeignKey implements XmlOperation<AddForeignKey> {
 
-	static final String TAG = "addForeignKey";
+	static final String TAG = "createForeignKey";
 
 	static XmlOperation convert(XmlElement element) {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlAddForeignKey operation = new XmlAddForeignKey();
-		operation.setTableName(element.getAttributes().get("tableName"));
-		operation.setColumnNames(element.getAttributes().get("columnNames").split(","));
-		operation.setReferencedTableName(element.getAttributes().get("referencesTableName"));
-		operation.setReferencedColumnNames(element.getAttributes().get("referencesColumnNames").split(","));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+		operation.setColumnNames(element.getAttributes().remove("columnNames").split(","));
+		operation.setReferencedTableName(element.getAttributes().remove("referencesTableName"));
+		operation.setReferencedColumnNames(element.getAttributes().remove("referencesColumnNames").split(","));
 
-		Optional.ofNullable(element.getAttributes().get("name"))
+		Optional.ofNullable(element.getAttributes().remove("name"))
 				.ifPresent(operation::setName);
 
-		Optional.ofNullable(element.getAttributes().get("onDelete"))
+		Optional.ofNullable(element.getAttributes().remove("onDelete"))
 				.map(Action::valueOf)
 				.ifPresent(operation::setOnDelete);
 
-		Optional.ofNullable(element.getAttributes().get("onUpdate"))
+		Optional.ofNullable(element.getAttributes().remove("onUpdate"))
 				.map(Action::valueOf)
 				.ifPresent(operation::setOnUpdate);
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
 
 		return operation;
 	}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterColumn.java
@@ -2,7 +2,6 @@ package io.quantumdb.cli.xml;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Map;
 import java.util.Optional;
 
 import io.quantumdb.core.schema.definitions.Column.Hint;
@@ -18,21 +17,24 @@ public class XmlAlterColumn implements XmlOperation<AlterColumn> {
 
 	static XmlOperation convert(XmlElement element) {
 		checkArgument(element.getTag().equals(TAG));
-		Map<String, String> attributes = element.getAttributes();
 
 		XmlAlterColumn operation = new XmlAlterColumn();
-		operation.setTableName(attributes.get("tableName"));
-		operation.setColumnName(attributes.get("columnName"));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+		operation.setColumnName(element.getAttributes().remove("columnName"));
 
-		Optional.ofNullable(attributes.get("newColumnName"))
+		Optional.ofNullable(element.getAttributes().remove("newColumnName"))
 				.ifPresent(operation::setNewColumnName);
 
-		Optional.ofNullable(attributes.get("newType"))
+		Optional.ofNullable(element.getAttributes().remove("newDataType"))
 				.ifPresent(operation::setNewType);
 
-		Optional.ofNullable(attributes.get("nullable"))
+		Optional.ofNullable(element.getAttributes().remove("nullable"))
 				.map(Boolean.TRUE.toString()::equals)
 				.ifPresent(operation::setNullable);
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
 
 		return operation;
 	}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterDefaultExpression.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlAlterDefaultExpression.java
@@ -2,8 +2,6 @@ package io.quantumdb.cli.xml;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Map;
-
 import io.quantumdb.core.schema.operations.AlterColumn;
 import io.quantumdb.core.schema.operations.SchemaOperations;
 import lombok.Data;
@@ -15,12 +13,16 @@ public class XmlAlterDefaultExpression implements XmlOperation<AlterColumn> {
 
 	static XmlOperation convert(XmlElement element) {
 		checkArgument(element.getTag().equals(TAG));
-		Map<String, String> attributes = element.getAttributes();
 
 		XmlAlterDefaultExpression operation = new XmlAlterDefaultExpression();
-		operation.setTableName(attributes.get("tableName"));
-		operation.setColumnName(attributes.get("columnName"));
-		operation.setDefaultExpression(attributes.get("defaultExpression"));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+		operation.setColumnName(element.getAttributes().remove("columnName"));
+		operation.setDefaultExpression(element.getAttributes().remove("defaultExpression"));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlChangeset.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlChangeset.java
@@ -15,8 +15,8 @@ public class XmlChangeset {
 		checkArgument(element.getTag().equals("changeset"));
 
 		XmlChangeset changeset = new XmlChangeset();
-		changeset.setId(element.getAttributes().get("id"));
-		changeset.setAuthor(element.getAttributes().get("author"));
+		changeset.setId(element.getAttributes().remove("id"));
+		changeset.setAuthor(element.getAttributes().remove("author"));
 
 		for (XmlElement child : element.getChildren()) {
 			if (child.getTag().equals("operations")) {
@@ -33,6 +33,13 @@ public class XmlChangeset {
 
 				changeset.setDescription(description);
 			}
+			else {
+				throw new IllegalArgumentException("Child element: " + child.getTag() + " is not valid!");
+			}
+		}
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
 		}
 
 		return changeset;

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlColumn.java
@@ -11,12 +11,17 @@ public class XmlColumn {
 		checkArgument(element.getTag().equals("column"));
 
 		XmlColumn column = new XmlColumn();
-		column.setName(element.getAttributes().get("name"));
-		column.setType(element.getAttributes().get("type"));
-		column.setDefaultExpression(element.getAttributes().get("defaultExpression"));
-		column.setPrimaryKey(Boolean.TRUE.toString().equals(element.getAttributes().get("primaryKey")));
-		column.setAutoIncrement(Boolean.TRUE.toString().equals(element.getAttributes().get("autoIncrement")));
-		column.setNullable(!Boolean.FALSE.toString().equals(element.getAttributes().get("nullable")));
+		column.setName(element.getAttributes().remove("name"));
+		column.setType(element.getAttributes().remove("type"));
+		column.setDefaultExpression(element.getAttributes().remove("defaultExpression"));
+		column.setPrimaryKey(Boolean.TRUE.toString().equals(element.getAttributes().remove("primaryKey")));
+		column.setAutoIncrement(Boolean.TRUE.toString().equals(element.getAttributes().remove("autoIncrement")));
+		column.setNullable(!Boolean.FALSE.toString().equals(element.getAttributes().remove("nullable")));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return column;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCopyTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCopyTable.java
@@ -15,8 +15,13 @@ public class XmlCopyTable implements XmlOperation<CopyTable> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlCopyTable operation = new XmlCopyTable();
-		operation.setSourceTableName(element.getAttributes().get("sourceTableName"));
-		operation.setTargetTableName(element.getAttributes().get("targetTableName"));
+		operation.setSourceTableName(element.getAttributes().remove("sourceTableName"));
+		operation.setTargetTableName(element.getAttributes().remove("targetTableName"));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateIndex.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateIndex.java
@@ -17,12 +17,16 @@ public class XmlCreateIndex implements XmlOperation<CreateIndex> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlCreateIndex operation = new XmlCreateIndex();
-		operation.setTableName(element.getAttributes().get("tableName"));
-		operation.setColumnNames(element.getAttributes().get("columnNames").split(","));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+		operation.setColumnNames(element.getAttributes().remove("columnNames").split(","));
 
-		Optional.ofNullable(element.getAttributes().get("unique"))
+		Optional.ofNullable(element.getAttributes().remove("unique"))
 				.map(Boolean.TRUE.toString()::equals)
 				.ifPresent(operation::setUnique);
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
 
 		return operation;
 	}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateTable.java
@@ -21,7 +21,7 @@ public class XmlCreateTable implements XmlOperation<CreateTable> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlCreateTable operation = new XmlCreateTable();
-		operation.setTableName(element.getAttributes().get("tableName"));
+		operation.setTableName(element.getAttributes().remove("tableName"));
 
 		for (XmlElement child : element.getChildren()) {
 			if (child.getTag().equals("columns")) {
@@ -29,6 +29,13 @@ public class XmlCreateTable implements XmlOperation<CreateTable> {
 					operation.getColumns().add(XmlColumn.convert(subChild));
 				}
 			}
+			else {
+				throw new IllegalArgumentException("Child element: " + child.getTag() + " is not valid!");
+			}
+		}
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
 		}
 
 		return operation;

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateView.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlCreateView.java
@@ -16,9 +16,9 @@ public class XmlCreateView implements XmlOperation<CreateView> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlCreateView operation = new XmlCreateView();
-		operation.setViewName(element.getAttributes().get("viewName"));
-		operation.setRecursive(Boolean.TRUE.toString().equals(element.getAttributes().get("recursive")));
-		operation.setTemporary(Boolean.TRUE.toString().equals(element.getAttributes().get("temporary")));
+		operation.setViewName(element.getAttributes().remove("viewName"));
+		operation.setRecursive(Boolean.TRUE.toString().equals(element.getAttributes().remove("recursive")));
+		operation.setTemporary(Boolean.TRUE.toString().equals(element.getAttributes().remove("temporary")));
 		operation.setQuery(Strings.emptyToNull(element.getChildren().stream()
 				.filter(child -> child.getTag().equals(XmlQuery.TAG))
 				.map(child -> (XmlQuery) XmlQuery.convert(child))
@@ -26,6 +26,10 @@ public class XmlCreateView implements XmlOperation<CreateView> {
 				.findFirst()
 				.orElseThrow(() -> new RuntimeException("No query specified!"))
 				.trim()));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
 
 		return operation;
 	}

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropColumn.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropColumn.java
@@ -15,8 +15,13 @@ public class XmlDropColumn implements XmlOperation<DropColumn> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlDropColumn operation = new XmlDropColumn();
-		operation.setTableName(element.getAttributes().get("tableName"));
-		operation.setColumnName(element.getAttributes().get("columnName"));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+		operation.setColumnName(element.getAttributes().remove("columnName"));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropDefaultExpression.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropDefaultExpression.java
@@ -2,8 +2,6 @@ package io.quantumdb.cli.xml;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Map;
-
 import io.quantumdb.core.schema.operations.AlterColumn;
 import io.quantumdb.core.schema.operations.SchemaOperations;
 import lombok.Data;
@@ -15,11 +13,15 @@ public class XmlDropDefaultExpression implements XmlOperation<AlterColumn> {
 
 	static XmlOperation convert(XmlElement element) {
 		checkArgument(element.getTag().equals(TAG));
-		Map<String, String> attributes = element.getAttributes();
 
 		XmlDropDefaultExpression operation = new XmlDropDefaultExpression();
-		operation.setTableName(attributes.get("tableName"));
-		operation.setColumnName(attributes.get("columnName"));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+		operation.setColumnName(element.getAttributes().remove("columnName"));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropForeignKey.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropForeignKey.java
@@ -15,8 +15,13 @@ public class XmlDropForeignKey implements XmlOperation<DropForeignKey> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlDropForeignKey operation = new XmlDropForeignKey();
-		operation.setTableName(element.getAttributes().get("tableName"));
-		operation.setForeignKeyName(element.getAttributes().get("foreignKeyName"));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+		operation.setForeignKeyName(element.getAttributes().remove("foreignKeyName"));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropIndex.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropIndex.java
@@ -15,8 +15,13 @@ public class XmlDropIndex implements XmlOperation<DropIndex> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlDropIndex operation = new XmlDropIndex();
-		operation.setTableName(element.getAttributes().get("tableName"));
-		operation.setColumnNames(element.getAttributes().get("columnNames").split(","));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+		operation.setColumnNames(element.getAttributes().remove("columnNames").split(","));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropTable.java
@@ -15,7 +15,12 @@ public class XmlDropTable implements XmlOperation<DropTable> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlDropTable operation = new XmlDropTable();
-		operation.setTableName(element.getAttributes().get("tableName"));
+		operation.setTableName(element.getAttributes().remove("tableName"));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropView.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlDropView.java
@@ -15,7 +15,12 @@ public class XmlDropView implements XmlOperation<DropView> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlDropView operation = new XmlDropView();
-		operation.setViewName(element.getAttributes().get("viewName"));
+		operation.setViewName(element.getAttributes().remove("viewName"));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlQuery.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlQuery.java
@@ -26,6 +26,10 @@ public class XmlQuery implements XmlOperation<DataOperation> {
 						.findFirst()
 						.orElseThrow(() -> new RuntimeException("No query specified!"))));
 
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlRenameTable.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlRenameTable.java
@@ -15,8 +15,13 @@ public class XmlRenameTable implements XmlOperation<RenameTable> {
 		checkArgument(element.getTag().equals(TAG));
 
 		XmlRenameTable operation = new XmlRenameTable();
-		operation.setOldTableName(element.getAttributes().get("oldTableName"));
-		operation.setNewTableName(element.getAttributes().get("newTableName"));
+		operation.setOldTableName(element.getAttributes().remove("oldTableName"));
+		operation.setNewTableName(element.getAttributes().remove("newTableName"));
+
+		if (!element.getAttributes().keySet().isEmpty()) {
+			throw new IllegalArgumentException("Attributes: " + element.getAttributes().keySet() + " is/are not valid!");
+		}
+
 		return operation;
 	}
 

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/ChangelogLoaderTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/ChangelogLoaderTest.java
@@ -1,0 +1,55 @@
+package io.quantumdb.cli.xml;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ChangelogLoaderTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+	}
+
+	@Test(expected = FileNotFoundException.class)
+	public void testChangeLogNotFound() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/NotFoundChangelog.xml");
+	}
+
+	@Test
+	public void testEmptyChangeLog() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/EmptyChangelog.xml");
+		assertNull(this.changelog.getRoot().getChangeSet());
+		assertNull(this.changelog.getRoot().getChild());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testDoubleIdChangeLog() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/DoubleIdChangelog.xml");
+	}
+
+	@Test
+	public void testMultipleChangeSetsChangeLog() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/MultipleChangesetChangelog.xml");
+		Version version = this.changelog.getRoot();
+		assertNull(version.getChangeSet());
+		version = version.getChild();
+		assertNotNull(version.getChangeSet());
+		version = version.getChild();
+		assertNotNull(version.getChangeSet());
+		version = version.getChild();
+		assertNotNull(version.getChangeSet());
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/MalformedChangelogTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/MalformedChangelogTest.java
@@ -1,0 +1,38 @@
+package io.quantumdb.cli.xml;
+
+import java.io.IOException;
+
+import io.quantumdb.core.versioning.Changelog;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MalformedChangelogTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMalformedAttribute() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/malformed-syntax/MalformedAttributeChangelog.xml");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMalformedChangelog() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/malformed-syntax/MalformedChangelog.xml");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMalformedChangeSet() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/malformed-syntax/MalformedChangeSetChangelog.xml");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMalformedChild() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/malformed-syntax/MalformedChildChangelog.xml");
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlAddColumnTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlAddColumnTest.java
@@ -1,0 +1,89 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.definitions.Column.Hint;
+import io.quantumdb.core.schema.definitions.ColumnType.Type;
+import io.quantumdb.core.schema.operations.AddColumn;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlAddColumnTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testAddColumn() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/AddColumnChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof AddColumn);
+		assertEquals(0, ((AddColumn) operation).getColumnDefinition().getHints().length);
+		assertNull(((AddColumn) operation).getColumnDefinition().getDefaultValueExpression());
+		assertEquals(Type.VARCHAR, ((AddColumn) operation).getColumnDefinition().getType().getType());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddColumn);
+		assertEquals(0, ((AddColumn) operation).getColumnDefinition().getHints().length);
+		assertNull(((AddColumn) operation).getColumnDefinition().getDefaultValueExpression());
+		assertEquals(Type.VARCHAR, ((AddColumn) operation).getColumnDefinition().getType().getType());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddColumn);
+		assertEquals(1, ((AddColumn) operation).getColumnDefinition().getHints().length);
+		assertEquals(Hint.NOT_NULL, ((AddColumn) operation).getColumnDefinition().getHints()[0]);
+		assertEquals("test", ((AddColumn) operation).getColumnDefinition().getDefaultValueExpression());
+		assertEquals(Type.VARCHAR, ((AddColumn) operation).getColumnDefinition().getType().getType());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddColumn);
+		assertEquals(1, ((AddColumn) operation).getColumnDefinition().getHints().length);
+		assertEquals(Hint.PRIMARY_KEY, ((AddColumn) operation).getColumnDefinition().getHints()[0]);
+		assertNull(((AddColumn) operation).getColumnDefinition().getDefaultValueExpression());
+		assertEquals(Type.NUMERIC, ((AddColumn) operation).getColumnDefinition().getType().getType());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddColumn);
+		assertEquals(1, ((AddColumn) operation).getColumnDefinition().getHints().length);
+		assertEquals(Hint.AUTO_INCREMENT, ((AddColumn) operation).getColumnDefinition().getHints()[0]);
+		assertNull(((AddColumn) operation).getColumnDefinition().getDefaultValueExpression());
+		assertEquals(Type.NUMERIC, ((AddColumn) operation).getColumnDefinition().getType().getType());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddColumn);
+		assertEquals(2, ((AddColumn) operation).getColumnDefinition().getHints().length);
+		assertNull(((AddColumn) operation).getColumnDefinition().getDefaultValueExpression());
+		assertEquals(Type.NUMERIC, ((AddColumn) operation).getColumnDefinition().getType().getType());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddColumn);
+		assertEquals(0, ((AddColumn) operation).getColumnDefinition().getHints().length);
+		assertEquals("test", ((AddColumn) operation).getColumnDefinition().getDefaultValueExpression());
+		assertEquals(Type.VARCHAR, ((AddColumn) operation).getColumnDefinition().getType().getType());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlAddForeignKeyTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlAddForeignKeyTest.java
@@ -1,0 +1,103 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.definitions.ForeignKey.Action;
+import io.quantumdb.core.schema.operations.AddForeignKey;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlAddForeignKeyTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testAddForeignKey() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/AddForeignKeyChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof AddForeignKey);
+		assertEquals("table1", ((AddForeignKey) operation).getReferringTableName());
+		assertEquals("table2", ((AddForeignKey) operation).getReferencedTableName());
+		assertEquals(1, ((AddForeignKey) operation).getReferringColumnNames().length);
+		assertEquals(1, ((AddForeignKey) operation).getReferencedColumnNames().length);
+		assertEquals("column1", ((AddForeignKey) operation).getReferringColumnNames()[0]);
+		assertEquals("column1", ((AddForeignKey) operation).getReferencedColumnNames()[0]);
+		assertEquals("foreign_key1", ((AddForeignKey) operation).getName());
+		assertEquals(Action.NO_ACTION, ((AddForeignKey) operation).getOnDelete());
+		assertEquals(Action.NO_ACTION, ((AddForeignKey) operation).getOnUpdate());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddForeignKey);
+		assertEquals("table1", ((AddForeignKey) operation).getReferringTableName());
+		assertEquals("table2", ((AddForeignKey) operation).getReferencedTableName());
+		assertEquals(2, ((AddForeignKey) operation).getReferringColumnNames().length);
+		assertEquals(2, ((AddForeignKey) operation).getReferencedColumnNames().length);
+		assertEquals("column1", ((AddForeignKey) operation).getReferringColumnNames()[0]);
+		assertEquals("column1", ((AddForeignKey) operation).getReferencedColumnNames()[0]);
+		assertEquals("column2", ((AddForeignKey) operation).getReferringColumnNames()[1]);
+		assertEquals("column2", ((AddForeignKey) operation).getReferencedColumnNames()[1]);
+		assertEquals("foreign_key2", ((AddForeignKey) operation).getName());
+		assertEquals(Action.NO_ACTION, ((AddForeignKey) operation).getOnDelete());
+		assertEquals(Action.NO_ACTION, ((AddForeignKey) operation).getOnUpdate());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddForeignKey);
+		assertEquals("table1", ((AddForeignKey) operation).getReferringTableName());
+		assertEquals("table2", ((AddForeignKey) operation).getReferencedTableName());
+		assertEquals(1, ((AddForeignKey) operation).getReferringColumnNames().length);
+		assertEquals(1, ((AddForeignKey) operation).getReferencedColumnNames().length);
+		assertEquals("column1", ((AddForeignKey) operation).getReferringColumnNames()[0]);
+		assertEquals("column1", ((AddForeignKey) operation).getReferencedColumnNames()[0]);
+		assertEquals("foreign_key3", ((AddForeignKey) operation).getName());
+		assertEquals(Action.RESTRICT, ((AddForeignKey) operation).getOnDelete());
+		assertEquals(Action.CASCADE, ((AddForeignKey) operation).getOnUpdate());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddForeignKey);
+		assertEquals("table1", ((AddForeignKey) operation).getReferringTableName());
+		assertEquals("table2", ((AddForeignKey) operation).getReferencedTableName());
+		assertEquals(1, ((AddForeignKey) operation).getReferringColumnNames().length);
+		assertEquals(1, ((AddForeignKey) operation).getReferencedColumnNames().length);
+		assertEquals("column1", ((AddForeignKey) operation).getReferringColumnNames()[0]);
+		assertEquals("column1", ((AddForeignKey) operation).getReferencedColumnNames()[0]);
+		assertEquals("foreign_key4", ((AddForeignKey) operation).getName());
+		assertEquals(Action.SET_DEFAULT, ((AddForeignKey) operation).getOnDelete());
+		assertEquals(Action.SET_NULL, ((AddForeignKey) operation).getOnUpdate());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AddForeignKey);
+		assertEquals("table1", ((AddForeignKey) operation).getReferringTableName());
+		assertEquals("table2", ((AddForeignKey) operation).getReferencedTableName());
+		assertEquals(1, ((AddForeignKey) operation).getReferringColumnNames().length);
+		assertEquals(1, ((AddForeignKey) operation).getReferencedColumnNames().length);
+		assertEquals("column1", ((AddForeignKey) operation).getReferringColumnNames()[0]);
+		assertEquals("column1", ((AddForeignKey) operation).getReferencedColumnNames()[0]);
+		assertEquals("foreign_key5", ((AddForeignKey) operation).getName());
+		assertEquals(Action.NO_ACTION, ((AddForeignKey) operation).getOnDelete());
+		assertEquals(Action.NO_ACTION, ((AddForeignKey) operation).getOnUpdate());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlAlterColumnTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlAlterColumnTest.java
@@ -1,0 +1,105 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.definitions.Column.Hint;
+import io.quantumdb.core.schema.definitions.ColumnType.Type;
+import io.quantumdb.core.schema.operations.AlterColumn;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlAlterColumnTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testAlterColumn() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/AlterColumnChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof AlterColumn);
+		assertEquals(1, ((AlterColumn) operation).getHintsToDrop().size());
+		assertEquals(0, ((AlterColumn) operation).getHintsToAdd().size());
+		assertEquals(Hint.NOT_NULL, ((AlterColumn) operation).getHintsToDrop().asList().get(0));
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnName());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnType());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewDefaultValueExpression());
+
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AlterColumn);
+		assertEquals(0, ((AlterColumn) operation).getHintsToDrop().size());
+		assertEquals(0, ((AlterColumn) operation).getHintsToAdd().size());
+		assertEquals("column2", ((AlterColumn) operation).getNewColumnName().get());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnType());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewDefaultValueExpression());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AlterColumn);
+		assertEquals(0, ((AlterColumn) operation).getHintsToDrop().size());
+		assertEquals(0, ((AlterColumn) operation).getHintsToAdd().size());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnName());
+		assertEquals(Type.TIMESTAMP, ((AlterColumn) operation).getNewColumnType().get().getType());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewDefaultValueExpression());
+
+//		version = version.getChild();
+//		operation = version.getOperation();
+//		assertTrue(operation instanceof AlterColumn);
+//		assertEquals(0, ((AlterColumn) operation).getHintsToDrop().size());
+//		assertEquals(1, ((AlterColumn) operation).getHintsToAdd().size());
+//		assertEquals(Hint.AUTO_INCREMENT, ((AlterColumn) operation).getHintsToAdd().asList().get(0));
+//		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnName());
+//		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnType());
+//		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewDefaultValueExpression());
+
+//		version = version.getChild();
+//		operation = version.getOperation();
+//		assertTrue(operation instanceof AlterColumn);
+//		assertEquals(0, ((AlterColumn) operation).getHintsToDrop().size());
+//		assertEquals(1, ((AlterColumn) operation).getHintsToAdd().size());
+//		assertEquals(Hint.PRIMARY_KEY, ((AlterColumn) operation).getHintsToAdd().asList().get(0));
+//		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnName());
+//		assertEquals(Type.BIGINT, ((AlterColumn) operation).getNewColumnType().get().getType());
+//		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewDefaultValueExpression());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AlterColumn);
+		assertEquals(0, ((AlterColumn) operation).getHintsToDrop().size());
+		assertEquals(0, ((AlterColumn) operation).getHintsToAdd().size());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnName());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnType());
+		assertEquals("NOW()", ((AlterColumn) operation).getNewDefaultValueExpression().get());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof AlterColumn);
+		assertEquals(0, ((AlterColumn) operation).getHintsToDrop().size());
+		assertEquals(0, ((AlterColumn) operation).getHintsToAdd().size());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnName());
+		assertEquals(Optional.empty(), ((AlterColumn) operation).getNewColumnType());
+		assertEquals("", ((AlterColumn) operation).getNewDefaultValueExpression().get());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlCopyTableTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlCopyTableTest.java
@@ -1,0 +1,41 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.CopyTable;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlCopyTableTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testCopyTable() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/CopyTableChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof CopyTable);
+		assertEquals("table1", ((CopyTable) operation).getSourceTableName());
+		assertEquals("table2", ((CopyTable) operation).getTargetTableName());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlCreateIndexTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlCreateIndexTest.java
@@ -1,0 +1,53 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.CreateIndex;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlCreateIndexTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testCreateIndex() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/CreateIndexChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof CreateIndex);
+		assertEquals("table1", ((CreateIndex) operation).getTableName());
+		assertEquals(1, ((CreateIndex) operation).getColumns().size());
+		assertEquals("column1", ((CreateIndex) operation).getColumns().asList().get(0));
+		assertFalse(((CreateIndex) operation).isUnique());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof CreateIndex);
+		assertEquals("table1", ((CreateIndex) operation).getTableName());
+		assertEquals(2, ((CreateIndex) operation).getColumns().size());
+		assertEquals("column1", ((CreateIndex) operation).getColumns().asList().get(0));
+		assertEquals("column2", ((CreateIndex) operation).getColumns().asList().get(1));
+		assertTrue(((CreateIndex) operation).isUnique());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlCreateTableTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlCreateTableTest.java
@@ -1,0 +1,60 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.definitions.Column.Hint;
+import io.quantumdb.core.schema.definitions.ColumnType.Type;
+import io.quantumdb.core.schema.operations.CreateTable;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlCreateTableTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testCreateTable() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/CreateTableChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof CreateTable);
+		assertEquals("table1", ((CreateTable) operation).getTableName());
+		assertEquals(5, ((CreateTable) operation).getColumns().size());
+		assertEquals(Type.BIGINT, ((CreateTable) operation).getColumns().get(0).getType().getType());
+		assertEquals(Type.VARCHAR, ((CreateTable) operation).getColumns().get(1).getType().getType());
+		assertEquals(Type.TIMESTAMP, ((CreateTable) operation).getColumns().get(2).getType().getType());
+		assertEquals(Type.NUMERIC, ((CreateTable) operation).getColumns().get(3).getType().getType());
+		assertEquals(Type.NUMERIC, ((CreateTable) operation).getColumns().get(4).getType().getType());
+		assertEquals(1, ((CreateTable) operation).getColumns().get(0).getHints().length);
+		assertEquals(0, ((CreateTable) operation).getColumns().get(1).getHints().length);
+		assertEquals(1, ((CreateTable) operation).getColumns().get(2).getHints().length);
+		assertEquals(1, ((CreateTable) operation).getColumns().get(3).getHints().length);
+		assertEquals(3, ((CreateTable) operation).getColumns().get(4).getHints().length);
+		assertEquals(Hint.PRIMARY_KEY, ((CreateTable) operation).getColumns().get(0).getHints()[0]);
+		assertEquals(Hint.NOT_NULL, ((CreateTable) operation).getColumns().get(2).getHints()[0]);
+		assertEquals(Hint.AUTO_INCREMENT, ((CreateTable) operation).getColumns().get(3).getHints()[0]);
+		assertEquals(Hint.PRIMARY_KEY, ((CreateTable) operation).getColumns().get(4).getHints()[0]);
+		assertEquals(Hint.AUTO_INCREMENT, ((CreateTable) operation).getColumns().get(4).getHints()[1]);
+		assertEquals(Hint.NOT_NULL, ((CreateTable) operation).getColumns().get(4).getHints()[2]);
+		assertEquals("Test", ((CreateTable) operation).getColumns().get(1).getDefaultValueExpression());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlCreateViewTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlCreateViewTest.java
@@ -1,0 +1,52 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.CreateView;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlCreateViewTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testCreateView() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/CreateViewChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof CreateView);
+		assertEquals("view1", ((CreateView) operation).getViewName());
+		assertEquals("SELECT * FROM table1 WHERE admin = true;", ((CreateView) operation).getQuery());
+		assertFalse(((CreateView) operation).isRecursive());
+		assertFalse(((CreateView) operation).isTemporary());
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof CreateView);
+		assertEquals("view2", ((CreateView) operation).getViewName());
+		assertEquals("SELECT * FROM table2 WHERE admin = true;", ((CreateView) operation).getQuery());
+		assertTrue(((CreateView) operation).isRecursive());
+		assertTrue(((CreateView) operation).isTemporary());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropColumnTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropColumnTest.java
@@ -1,0 +1,41 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.DropColumn;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlDropColumnTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testDropColumn() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/DropColumnChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof DropColumn);
+		assertEquals("table1", ((DropColumn) operation).getTableName());
+		assertEquals("column1", ((DropColumn) operation).getColumnName());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropForeignKeyTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropForeignKeyTest.java
@@ -1,0 +1,41 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.DropForeignKey;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlDropForeignKeyTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testDropForeignKey() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/DropForeignKeyChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof DropForeignKey);
+		assertEquals("table1", ((DropForeignKey) operation).getTableName());
+		assertEquals("foreign_key1", ((DropForeignKey) operation).getForeignKeyName());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropIndexTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropIndexTest.java
@@ -1,0 +1,50 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.DropIndex;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlDropIndexTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testDropIndex() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/DropIndexChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof DropIndex);
+		assertEquals("table1", ((DropIndex) operation).getTableName());
+		assertEquals(1, ((DropIndex) operation).getColumns().length);
+		assertEquals("column1", ((DropIndex) operation).getColumns()[0]);
+
+		version = version.getChild();
+		operation = version.getOperation();
+		assertTrue(operation instanceof DropIndex);
+		assertEquals("table1", ((DropIndex) operation).getTableName());
+		assertEquals(2, ((DropIndex) operation).getColumns().length);
+		assertEquals("column1", ((DropIndex) operation).getColumns()[0]);
+		assertEquals("column2", ((DropIndex) operation).getColumns()[1]);
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropTableTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropTableTest.java
@@ -1,0 +1,40 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.DropTable;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlDropTableTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testDropTable() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/DropTableChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof DropTable);
+		assertEquals("table1", ((DropTable) operation).getTableName());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropViewTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlDropViewTest.java
@@ -1,0 +1,40 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.DropView;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlDropViewTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testDropView() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/DropViewChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof DropView);
+		assertEquals("view1", ((DropView) operation).getViewName());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlQueryTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlQueryTest.java
@@ -1,0 +1,40 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.DataOperation;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlQueryTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testQuery() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/QueryChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof DataOperation);
+		assertEquals("INSERT VALUES (\"user1\", 1, \"Nick\") INTO table1;", ((DataOperation) operation).getQuery());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlRenameTableTest.java
+++ b/quantumdb-cli/src/test/java/io/quantumdb/cli/xml/operations/XmlRenameTableTest.java
@@ -1,0 +1,41 @@
+package io.quantumdb.cli.xml.operations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import io.quantumdb.cli.xml.ChangelogLoader;
+import io.quantumdb.core.schema.operations.Operation;
+import io.quantumdb.core.schema.operations.RenameTable;
+import io.quantumdb.core.versioning.Changelog;
+import io.quantumdb.core.versioning.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlRenameTableTest {
+
+	private Changelog changelog;
+
+	@Before
+	public void setUp() {
+		this.changelog = new Changelog();
+
+	}
+
+	@Test
+	public void testRenameTable() throws IOException {
+		this.changelog = new ChangelogLoader().load(this.changelog, "src/test/resources/operations/RenameTableChangelog.xml");
+
+		Version version = this.changelog.getRoot().getChild();
+		Operation operation = version.getOperation();
+		assertTrue(operation instanceof RenameTable);
+		assertEquals("table1", ((RenameTable) operation).getTableName());
+		assertEquals("table2", ((RenameTable) operation).getNewTableName());
+
+		version = version.getChild();
+		assertNull(version);
+	}
+
+}

--- a/quantumdb-cli/src/test/resources/DoubleIdChangelog.xml
+++ b/quantumdb-cli/src/test/resources/DoubleIdChangelog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id" author="Nick Richter">
+		<description>Test changeset</description>
+		<operations>
+			<addColumn tableName="table1">
+				<column name="column1" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id" author="Nick Richter">
+		<description>Test changeset</description>
+		<operations>
+			<addColumn tableName="table1">
+				<column name="column1" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/EmptyChangelog.xml
+++ b/quantumdb-cli/src/test/resources/EmptyChangelog.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/MultipleChangesetChangelog.xml
+++ b/quantumdb-cli/src/test/resources/MultipleChangesetChangelog.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<addColumn tableName="table1">
+				<column name="column1" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<addColumn tableName="table2">
+				<column name="column2" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id3" author="Nick Richter">
+		<description>Test changeset 3</description>
+		<operations>
+			<addColumn tableName="table3">
+				<column name="column3" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/malformed-syntax/MalformedAttributeChangelog.xml
+++ b/quantumdb-cli/src/test/resources/malformed-syntax/MalformedAttributeChangelog.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter" description="Test changeset 1">
+		<description>Test changeset 1</description>
+		<operations>
+			<addColumn tableName="table1">
+				<column name="column1" type="varchar"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<addColumn tableName="table2">
+				<column name="column2" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id3" author="Nick Richter">
+		<description>Test changeset 3</description>
+		<operations>
+			<addColumn tableName="table3">
+				<column name="column3" type="varchar" nullable="false" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id4" author="Nick Richter">
+		<description>Test changeset 4</description>
+		<operations>
+			<addColumn tableName="table4">
+				<column name="column4" type="numeric" primaryKey="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id5" author="Nick Richter">
+		<description>Test changeset 5</description>
+		<operations>
+			<addColumn tableName="table5">
+				<column name="column5" type="numeric" autoIncrement="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id6" author="Nick Richter">
+		<description>Test changeset 6</description>
+		<operations>
+			<addColumn tableName="table6">
+				<column name="column6" type="numeric" primaryKey="true" nullable="false"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id7" author="Nick Richter">
+		<description>Test changeset 7</description>
+		<operations>
+			<addColumn tableName="table7">
+				<column name="column7" type="varchar" nullable="true" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/malformed-syntax/MalformedChangeSetChangelog.xml
+++ b/quantumdb-cli/src/test/resources/malformed-syntax/MalformedChangeSetChangelog.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<addColumn tableName="table1">
+				<column name="column1" type="varchar"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeSet id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<addColumn tableName="table2">
+				<column name="column2" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeSet>
+
+	<changeset id="id3" author="Nick Richter">
+		<description>Test changeset 3</description>
+		<operations>
+			<addColumn tableName="table3">
+				<column name="column3" type="varchar" nullable="false" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id4" author="Nick Richter">
+		<description>Test changeset 4</description>
+		<operations>
+			<addColumn tableName="table4">
+				<column name="column4" type="numeric" primaryKey="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id5" author="Nick Richter">
+		<description>Test changeset 5</description>
+		<operations>
+			<addColumn tableName="table5">
+				<column name="column5" type="numeric" autoIncrement="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id6" author="Nick Richter">
+		<description>Test changeset 6</description>
+		<operations>
+			<addColumn tableName="table6">
+				<column name="column6" type="numeric" primaryKey="true" nullable="false"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id7" author="Nick Richter">
+		<description>Test changeset 7</description>
+		<operations>
+			<addColumn tableName="table7">
+				<column name="column7" type="varchar" nullable="true" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/malformed-syntax/MalformedChangelog.xml
+++ b/quantumdb-cli/src/test/resources/malformed-syntax/MalformedChangelog.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changeLog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<addColumn tableName="table1">
+				<column name="column1" type="varchar"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<addColumn tableName="table2">
+				<column name="column2" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id3" author="Nick Richter">
+		<description>Test changeset 3</description>
+		<operations>
+			<addColumn tableName="table3">
+				<column name="column3" type="varchar" nullable="false" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id4" author="Nick Richter">
+		<description>Test changeset 4</description>
+		<operations>
+			<addColumn tableName="table4">
+				<column name="column4" type="numeric" primaryKey="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id5" author="Nick Richter">
+		<description>Test changeset 5</description>
+		<operations>
+			<addColumn tableName="table5">
+				<column name="column5" type="numeric" autoIncrement="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id6" author="Nick Richter">
+		<description>Test changeset 6</description>
+		<operations>
+			<addColumn tableName="table6">
+				<column name="column6" type="numeric" primaryKey="true" nullable="false"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id7" author="Nick Richter">
+		<description>Test changeset 7</description>
+		<operations>
+			<addColumn tableName="table7">
+				<column name="column7" type="varchar" nullable="true" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+</changeLog>

--- a/quantumdb-cli/src/test/resources/malformed-syntax/MalformedChildChangelog.xml
+++ b/quantumdb-cli/src/test/resources/malformed-syntax/MalformedChildChangelog.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<decomposeTable/>
+			<addColumn tableName="table1">
+				<column name="column1" type="varchar"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<addColumn tableName="table2">
+				<column name="column2" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id3" author="Nick Richter">
+		<description>Test changeset 3</description>
+		<operations>
+			<addColumn tableName="table3">
+				<column name="column3" type="varchar" nullable="false" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id4" author="Nick Richter">
+		<description>Test changeset 4</description>
+		<operations>
+			<addColumn tableName="table4">
+				<column name="column4" type="numeric" primaryKey="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id5" author="Nick Richter">
+		<description>Test changeset 5</description>
+		<operations>
+			<addColumn tableName="table5">
+				<column name="column5" type="numeric" autoIncrement="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id6" author="Nick Richter">
+		<description>Test changeset 6</description>
+		<operations>
+			<addColumn tableName="table6">
+				<column name="column6" type="numeric" primaryKey="true" nullable="false"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id7" author="Nick Richter">
+		<description>Test changeset 7</description>
+		<operations>
+			<addColumn tableName="table7">
+				<column name="column7" type="varchar" nullable="true" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/AddColumnChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/AddColumnChangelog.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<addColumn tableName="table1">
+				<column name="column1" type="varchar"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<addColumn tableName="table2">
+				<column name="column2" type="varchar" nullable="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id3" author="Nick Richter">
+		<description>Test changeset 3</description>
+		<operations>
+			<addColumn tableName="table3">
+				<column name="column3" type="varchar" nullable="false" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id4" author="Nick Richter">
+		<description>Test changeset 4</description>
+		<operations>
+			<addColumn tableName="table4">
+				<column name="column4" type="numeric" primaryKey="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id5" author="Nick Richter">
+		<description>Test changeset 5</description>
+		<operations>
+			<addColumn tableName="table5">
+				<column name="column5" type="numeric" autoIncrement="true"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id6" author="Nick Richter">
+		<description>Test changeset 6</description>
+		<operations>
+			<addColumn tableName="table6">
+				<column name="column6" type="numeric" primaryKey="true" nullable="false"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+	<changeset id="id7" author="Nick Richter">
+		<description>Test changeset 7</description>
+		<operations>
+			<addColumn tableName="table7">
+				<column name="column7" type="varchar" nullable="true" defaultExpression="test"/>
+			</addColumn>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/AddForeignKeyChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/AddForeignKeyChangelog.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<createForeignKey tableName="table1" columnNames="column1" referencesTableName="table2"
+						   referencesColumnNames="column1" name="foreign_key1"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<createForeignKey tableName="table1" columnNames="column1,column2" referencesTableName="table2"
+						   referencesColumnNames="column1,column2" name="foreign_key2"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id3" author="Nick Richter">
+		<description>Test changeset 3</description>
+		<operations>
+			<createForeignKey tableName="table1" columnNames="column1" referencesTableName="table2"
+						   referencesColumnNames="column1" name="foreign_key3" onDelete="RESTRICT" onUpdate="CASCADE"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id4" author="Nick Richter">
+		<description>Test changeset 4</description>
+		<operations>
+			<createForeignKey tableName="table1" columnNames="column1" referencesTableName="table2"
+						   referencesColumnNames="column1" name="foreign_key4" onDelete="SET_DEFAULT"
+						   onUpdate="SET_NULL"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id5" author="Nick Richter">
+		<description>Test changeset 5</description>
+		<operations>
+			<createForeignKey tableName="table1" columnNames="column1" referencesTableName="table2"
+						   referencesColumnNames="column1" name="foreign_key5" onDelete="NO_ACTION"
+						   onUpdate="NO_ACTION"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/AlterColumnChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/AlterColumnChangelog.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<alterColumn tableName="table1" columnName="column1" nullable="true"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<alterColumn tableName="table1" columnName="column1" newColumnName="column2"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id3" author="Nick Richter">
+		<description>Test changeset 3</description>
+		<operations>
+			<alterColumn tableName="table1" columnName="column1" newDataType="TIMESTAMP"/>
+		</operations>
+	</changeset>
+
+	<!--	<changeset id="id4" author="Nick Richter">-->
+	<!--		<description>Test changeset 4</description>-->
+	<!--		<operations>-->
+	<!--			<alterColumn tableName="table1" columnName="column1" autoIncrement="true" />-->
+	<!--		</operations>-->
+	<!--	</changeset>-->
+
+	<!--	<changeset id="id5" author="Nick Richter">-->
+	<!--		<description>Test changeset 5</description>-->
+	<!--		<operations>-->
+	<!--			<alterColumn tableName="table1" columnName="column1" newDataType="bigserial" primaryKey="true" />-->
+	<!--		</operations>-->
+	<!--	</changeset>-->
+
+	<changeset id="id6" author="Nick Richter">
+		<description>Test changeset 6</description>
+		<operations>
+			<alterDefaultExpression tableName="table1" columnName="column1" defaultExpression="NOW()"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id7" author="Nick Richter">
+		<description>Test changeset 7</description>
+		<operations>
+			<dropDefaultExpression tableName="table1" columnName="column1"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/CopyTableChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/CopyTableChangelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<copyTable sourceTableName="table1" targetTableName="table2"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/CreateIndexChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/CreateIndexChangelog.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<createIndex tableName="table1" columnNames="column1"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<createIndex tableName="table1" columnNames="column1,column2" unique="true"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/CreateTableChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/CreateTableChangelog.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<createTable tableName="table1">
+				<columns>
+					<column name="column1" type="bigserial" primaryKey="true"/>
+					<column name="column2" type="varchar" defaultExpression="Test"/>
+					<column name="column3" type="timestamp" nullable="false"/>
+					<column name="column4" type="numeric" autoIncrement="true"/>
+					<column name="column5" type="numeric" nullable="false" autoIncrement="true" primaryKey="true"/>
+				</columns>
+			</createTable>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/CreateViewChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/CreateViewChangelog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<createView viewName="view1">
+				<sql>
+					SELECT * FROM table1 WHERE admin = true;
+				</sql>
+			</createView>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<createView viewName="view2" temporary="true" recursive="true">
+				<sql>
+					SELECT * FROM table2 WHERE admin = true;
+				</sql>
+			</createView>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/DropColumnChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/DropColumnChangelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<dropColumn tableName="table1" columnName="column1"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/DropForeignKeyChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/DropForeignKeyChangelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<dropForeignKey tableName="table1" foreignKeyName="foreign_key1"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/DropIndexChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/DropIndexChangelog.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<dropIndex tableName="table1" columnNames="column1"/>
+		</operations>
+	</changeset>
+
+	<changeset id="id2" author="Nick Richter">
+		<description>Test changeset 2</description>
+		<operations>
+			<dropIndex tableName="table1" columnNames="column1,column2"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/DropTableChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/DropTableChangelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<dropTable tableName="table1"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/DropViewChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/DropViewChangelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<dropView viewName="view1"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/QueryChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/QueryChangelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<sql>INSERT VALUES ("user1", 1, "Nick") INTO table1;</sql>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-cli/src/test/resources/operations/RenameTableChangelog.xml
+++ b/quantumdb-cli/src/test/resources/operations/RenameTableChangelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<changelog
+		xmlns="http://www.quantumdb.io/xml/ns/quantumdb-changelog"
+>
+
+	<changeset id="id1" author="Nick Richter">
+		<description>Test changeset 1</description>
+		<operations>
+			<renameTable oldTableName="table1" newTableName="table2"/>
+		</operations>
+	</changeset>
+
+</changelog>

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/AlterColumn.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/operations/AlterColumn.java
@@ -73,7 +73,7 @@ public class AlterColumn implements SchemaOperation {
 	}
 
 	public AlterColumn dropDefaultExpression() {
-		this.newDefaultValueExpression = Optional.ofNullable("");
+		this.newDefaultValueExpression = Optional.of("");
 		return this;
 	}
 


### PR DESCRIPTION
I added some unit tests for the cli package as some bugs were found when testing.
Additionally, functionality is implemented that will throw an error when malformed syntax is provided in the syntax.

Some mistakes in the XML namespace were found, addForeignKey -> createForeignKey and in the alterColumn element newType -> newDataType. I would suggest modifying these in the next version.