### PR TITLE
Bug fixes

### DIFF
--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/commands/Query.java
@@ -11,8 +11,7 @@ import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
+
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -41,8 +40,7 @@ public class Query extends Command {
 		try {
 			Config config = Config.load();
 			Version version = getVersionId(arguments, config);
-			String query = arguments.stream()
-					.collect(Collectors.joining(" "));
+			String query = String.join(" ", arguments);
 
 			Class.forName("io.quantumdb.driver.Driver");
 
@@ -200,7 +198,7 @@ public class Query extends Command {
 			throw new CliException("You must specify a Changeset ID to query!");
 		});
 		Version version = state.getChangelog().getRoot();
-		while (version != null && !version.getChangeSet().equals(changeSetId)) {
+		while (version != null && !version.getChangeSet().getId().equals(changeSetId)) {
 			version = version.getChild();
 		}
 		if (version == null) {

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/ChangelogLoader.java
@@ -3,6 +3,7 @@ package io.quantumdb.cli.xml;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.quantumdb.core.schema.operations.Operation;

--- a/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlMapper.java
+++ b/quantumdb-cli/src/main/java/io/quantumdb/cli/xml/XmlMapper.java
@@ -75,7 +75,20 @@ public class XmlMapper {
 
 					if (stack.size() > 0) {
 						XmlElement parent = stack.get(stack.size() - 1);
-						parent.getChildren().add(element);
+						if (parent.getTag() == null) {
+							element = new XmlElement(null, parent.getText().concat(body));
+							element.getChildren().addAll(parent.getChildren());
+							element.getAttributes().putAll(parent.getAttributes());
+							if (stack.size() > 1) {
+								XmlElement grandParent = stack.get(stack.size() - 2);
+								grandParent.getChildren().remove(parent);
+								grandParent.getChildren().add(element);
+							}
+							stack.remove(parent);
+						}
+						else {
+							parent.getChildren().add(element);
+						}
 					}
 
 					stack.add(element);

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AlterColumnMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/AlterColumnMigrator.java
@@ -50,8 +50,8 @@ class AlterColumnMigrator implements SchemaOperationMigrator<AlterColumn> {
 			}
 		});
 
-		operation.getHintsToDrop().stream().forEach(column::dropHint);
-		operation.getHintsToAdd().stream().forEach(column::addHint);
+		operation.getHintsToDrop().forEach(column::dropHint);
+		operation.getHintsToAdd().forEach(column::addHint);
 		operation.getNewColumnType().ifPresent(column::modifyType);
 
 		Optional<String> newDefaultValueExpression = operation.getNewDefaultValueExpression();

--- a/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropColumnMigrator.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/migration/operations/DropColumnMigrator.java
@@ -30,7 +30,9 @@ class DropColumnMigrator implements SchemaOperationMigrator<DropColumn> {
 
 		List<Index> indexes = Lists.newArrayList(table.getIndexes());
 		for (Index index : indexes) {
-			table.removeIndex(index.getColumns());
+			if (index.getColumns().contains(operation.getColumnName())) {
+				table.removeIndex(index.getColumns());
+			}
 		}
 	}
 

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Table.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Table.java
@@ -116,7 +116,7 @@ public class Table implements Copyable<Table>, Comparable<Table> {
 		checkArgument(!columns.isEmpty(), "You must specify at least one entry in 'columns'.");
 
 		return indexes.stream()
-				.anyMatch(c -> c.getColumns().equals(Lists.newArrayList(columns)));
+				.anyMatch(c -> c.getColumns().size() == Lists.newArrayList(columns).size() && c.getColumns().containsAll(Lists.newArrayList(columns)));
 	}
 
 	public Index removeIndex(String... columns) {
@@ -140,7 +140,7 @@ public class Table implements Copyable<Table>, Comparable<Table> {
 		checkArgument(!columns.isEmpty(), "You must specify at least one 'columns'.");
 
 		return indexes.stream()
-				.filter(c -> c.getColumns().equals(Lists.newArrayList(columns)))
+				.filter(c -> c.getColumns().size() == Lists.newArrayList(columns).size() && c.getColumns().containsAll(Lists.newArrayList(columns)))
 				.findFirst()
 				.orElse(null);
 	}

--- a/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Table.java
+++ b/quantumdb-core/src/main/java/io/quantumdb/core/schema/definitions/Table.java
@@ -101,29 +101,35 @@ public class Table implements Copyable<Table>, Comparable<Table> {
 
 	public Table addIndex(Index index) {
 		checkArgument(index != null, "You must specify an 'index'.");
-		checkState(!containsIndex(index.getColumns()), "Table already contains an index: " + index.getIndexName() + " with columns: " + index.getColumns());
+		checkState(!containsIndexName(index.getIndexName()), "Table already contains an index with the name: " + index.getIndexName());
 
 		indexes.add(index);
 		index.setParent(this);
 		return this;
 	}
 
-	public boolean containsIndex(String... columns) {
-		return containsIndex(Sets.newHashSet(columns));
+	public boolean containsIndexName(String indexName) {
+		checkArgument(indexName != null, "The indexName cannot be null.");
+
+		return indexes.stream().anyMatch(i -> i.getIndexName().equals(indexName));
 	}
 
-	public boolean containsIndex(Collection<String> columns) {
+	public boolean containsIndex(String... columns) {
+		return containsIndex(Lists.newArrayList(columns));
+	}
+
+	public boolean containsIndex(List<String> columns) {
 		checkArgument(!columns.isEmpty(), "You must specify at least one entry in 'columns'.");
 
 		return indexes.stream()
-				.anyMatch(c -> Sets.newHashSet(c.getColumns()).equals(Sets.newHashSet(columns)));
+				.anyMatch(i -> i.getColumns().equals(columns));
 	}
 
 	public Index removeIndex(String... columns) {
-		return removeIndex(Sets.newHashSet(columns));
+		return removeIndex(Lists.newArrayList(columns));
 	}
 
-	public Index removeIndex(Collection<String> columns) {
+	public Index removeIndex(List<String> columns) {
 		checkState(containsIndex(columns), "You cannot remove an index which does not exist: " + columns);
 
 		Index index = getIndex(columns);
@@ -133,14 +139,14 @@ public class Table implements Copyable<Table>, Comparable<Table> {
 	}
 
 	public Index getIndex(String... columns) {
-		return getIndex(Sets.newHashSet(columns));
+		return getIndex(Lists.newArrayList(columns));
 	}
 
-	public Index getIndex(Collection<String> columns) {
+	public Index getIndex(List<String> columns) {
 		checkArgument(!columns.isEmpty(), "You must specify at least one 'columns'.");
 
 		return indexes.stream()
-				.filter(c -> Sets.newHashSet(c.getColumns()).equals(Sets.newHashSet(columns)))
+				.filter(i -> i.getColumns().equals(columns))
 				.findFirst()
 				.orElse(null);
 	}

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
@@ -316,7 +316,7 @@ class CatalogLoader {
 				parser.present("CONCURRENTLY");
 				String indexName = parser.consume();
 				indexName = removeOuterQuotes(indexName);
-				if (indexName.startsWith("pk_")) {
+				if (indexName.endsWith("_pkey")) {
 					continue;
 				}
 

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/CatalogLoader.java
@@ -334,11 +334,13 @@ class CatalogLoader {
 					parser.consume();
 				}
 
-				List<String> groups = parser.consumeGroup('(', ')', ',').stream().map(String::trim).collect(Collectors.toList());
+				List<String> groups = parser.consumeGroup('(', ')', ',').stream().map(String::trim).map(CatalogLoader::removeOuterQuotes).collect(Collectors.toList());
 				// TODO: Add support for expressions. Now we only support column references.
 
 				Table table = catalog.getTable(indexTableName);
-				table.addIndex(new Index(indexName, groups, unique));
+				if (!table.containsIndex(groups)) {
+					table.addIndex(new Index(indexName, groups, unique));
+				}
 			}
 		}
 	}

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/SelectiveMigratorFunction.java
@@ -288,7 +288,7 @@ public class SelectiveMigratorFunction {
 		createStatement.append("		LIMIT " + batchSize);
 		createStatement.append("	LOOP");
 		createStatement.append("	  BEGIN");
-		createStatement.append("		INSERT INTO " + target.getName());
+		createStatement.append("		INSERT INTO " + quoted(target.getName()));
 		createStatement.append("		  (" + values.keySet().stream().map(QueryUtils::quoted).collect(Collectors.joining(", ")) + ")");
 		createStatement.append("		  VALUES (" + Joiner.on(", ").join(values.values()) + ");");
 		createStatement.append("	  EXCEPTION WHEN unique_violation THEN END;");

--- a/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
+++ b/quantumdb-postgresql/src/main/java/io/quantumdb/core/planner/TableDataMigrator.java
@@ -157,7 +157,7 @@ class TableDataMigrator {
 				if (resultSet.next()) {
 					Map<String, Object> id = Maps.newHashMap();
 					for (String primaryKeyColumn : primaryKeyColumns) {
-						Object value = resultSet.getObject(primaryKeyColumn);
+						Object value = parseValue(from.getColumn(primaryKeyColumn).getType().getType(),resultSet.getObject(primaryKeyColumn).toString());
 						id.put(primaryKeyColumn, value);
 					}
 					return id;

--- a/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
+++ b/quantumdb-postgresql/src/test/java/io/quantumdb/core/backends/integration/multistate/MultiStateTest.java
@@ -20,6 +20,7 @@ import io.quantumdb.core.migration.Migrator;
 import io.quantumdb.core.versioning.Changelog;
 import io.quantumdb.core.versioning.State;
 import io.quantumdb.core.versioning.Version;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -77,6 +78,11 @@ public class MultiStateTest extends PostgresqlDatabase {
 		migrator.migrate(state, step0.getId(), step1.getId());
 		migrator.migrate(state, step1.getId(), step4.getId());
 		migrator.drop(step1.getId());
+	}
+
+	@After
+	public void dropDatabase() {
+		super.after();
 	}
 
 }

--- a/quantumdb-query-rewriter/src/main/java/io/quantumdb/query/rewriter/PostgresqlQueryRewriter.java
+++ b/quantumdb-query-rewriter/src/main/java/io/quantumdb/query/rewriter/PostgresqlQueryRewriter.java
@@ -51,31 +51,32 @@ public class PostgresqlQueryRewriter implements QueryRewriter {
 		for (state.cursor = 0; state.cursor < query.length(); state.cursor++) {
 			char currentCharacter = query.charAt(state.cursor);
 
-				switch (currentCharacter) {
-					case '\'':
-					case '\"':
-					case '`':
-						Character onStack = state.stack.peekFirst();
-						if (onStack != null && onStack.equals(currentCharacter)) {
-							state.stack.removeFirst();
-						}
-						else {
-							state.stack.addFirst(currentCharacter);
-						}
-						processWordStartOrMiddle(state);
-						break;
-					case ' ':
-					case ',':
-					case ';':
-						if (state.stack.isEmpty()) {
-							processWordEnding(state);
-						}
-						processWordStartOrMiddle(state);
-						break;
-					default:
-						processWordStartOrMiddle(state);
-						break;
-				}
+			switch (currentCharacter) {
+				case '\'':
+				case '\"':
+				case '`':
+					Character onStack = state.stack.peekFirst();
+					if (onStack != null && onStack.equals(currentCharacter)) {
+						state.stack.removeFirst();
+					}
+					else {
+						state.stack.addFirst(currentCharacter);
+					}
+					processWordStartOrMiddle(state);
+					break;
+				case ' ':
+				case '\t':
+				case ',':
+				case ';':
+					if (state.stack.isEmpty()) {
+						processWordEnding(state);
+					}
+					processWordStartOrMiddle(state);
+					break;
+				default:
+					processWordStartOrMiddle(state);
+					break;
+			}
 		}
 
 		processWordEnding(state);
@@ -115,7 +116,7 @@ public class PostgresqlQueryRewriter implements QueryRewriter {
 			}
 
 			String schema = null;
-			if (word != null && word.startsWith(DEFAULT_SCHEMA + ".")) {
+			if (word.startsWith(DEFAULT_SCHEMA + ".")) {
 				schema = DEFAULT_SCHEMA;
 				word = word.substring(DEFAULT_SCHEMA.length() + 1, word.length());
 			}
@@ -131,19 +132,19 @@ public class PostgresqlQueryRewriter implements QueryRewriter {
 				}
 			}
 
-			if (tableName == null) {
-				//throw new SQLException("No table with name: '" + word + "' exists.");
-			}
-			else {
+			if (tableName != null) {
 				word = tableName;
 			}
+//			else {
+//				throw new SQLException("No table with name: '" + word + "' exists.");
+//			}
 
 			if (schema != null) {
 				word = schema + "." + word;
 			}
 
 			if (isQuoted) {
-				word = "'" + word + "'";
+				word = "\"" + word + "\"";
 			}
 		}
 
@@ -159,7 +160,7 @@ public class PostgresqlQueryRewriter implements QueryRewriter {
 			return false;
 		}
 
-		return first == '\'';
+		return first == '\"';
 	}
 
 }

--- a/quantumdb-query-rewriter/src/test/java/io/quantumdb/query/rewriter/PostgresqlQueryRewriterTest.java
+++ b/quantumdb-query-rewriter/src/test/java/io/quantumdb/query/rewriter/PostgresqlQueryRewriterTest.java
@@ -48,15 +48,15 @@ public class PostgresqlQueryRewriterTest {
 
 	@Test
 	public void testSelectQueryWithTableNameBetweenQuotes() throws SQLException {
-		String input = "SELECT * FROM 'users'";
-		String expected = "SELECT * FROM 'users_v2'";
+		String input = "SELECT * FROM \"users\"";
+		String expected = "SELECT * FROM \"users_v2\"";
 		assertEquals(expected, rewrite(input));
 	}
 
 	@Ignore
 	@Test(expected = SQLException.class)
 	public void testThatQuotedTableNameInFromIsCaseSensitive() throws SQLException {
-		String input = "SELECT * FROM 'Users'";
+		String input = "SELECT * FROM \"Users\"";
 		rewrite(input);
 	}
 


### PR DESCRIPTION
SAXParser calls the characters() function per 2 lines, this caused the SQL operation to only execute the first 2 lines, this fixes #90 

Additionally, when a tab character \t was placed before a keyword such as UPDATE or FROM, the table would not be rewritten into the correct table name.

Another bug was the dropping of an index when you had not specified the columns in the exact order. When a column was renamed that was part of an index it would also change places in the arraylist and it could not be found.

In SQL, single quotes \' are for string literals, while double quotes \" are used for case-sensitive tables or columns. This was not correct in the query rewriter.